### PR TITLE
[Feat]참가자 관련 api 구현

### DIFF
--- a/backend/src/main/java/com/pickeat/backend/room/application/ParticipantService.java
+++ b/backend/src/main/java/com/pickeat/backend/room/application/ParticipantService.java
@@ -1,0 +1,27 @@
+package com.pickeat.backend.room.application;
+
+import com.pickeat.backend.room.application.dto.ParticipantRequest;
+import com.pickeat.backend.room.application.dto.ParticipantResponse;
+import com.pickeat.backend.room.domain.Participant;
+import com.pickeat.backend.room.domain.Room;
+import com.pickeat.backend.room.domain.repository.ParticipantRepository;
+import com.pickeat.backend.room.domain.repository.RoomRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ParticipantService {
+
+    private final ParticipantRepository participantRepository;
+    private final RoomRepository roomRepository;
+
+    public ParticipantResponse createParticipant(ParticipantRequest request) {
+        Room room = roomRepository.findRoomByCode(UUID.fromString(request.roomCode()))
+                .orElseThrow(() -> new IllegalArgumentException("Room not found with code: " + request.roomCode()));
+        Participant participant = new Participant(request.nickname(), room);
+        Participant saved = participantRepository.save(participant);
+        return ParticipantResponse.from(saved);
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/room/application/ParticipantService.java
+++ b/backend/src/main/java/com/pickeat/backend/room/application/ParticipantService.java
@@ -20,7 +20,7 @@ public class ParticipantService {
 
     @Transactional
     public ParticipantResponse createParticipant(ParticipantRequest request) {
-        Room room = roomRepository.findRoomByCode(UUID.fromString(request.roomCode()))
+        Room room = roomRepository.findByCode(UUID.fromString(request.roomCode()))
                 .orElseThrow(() -> new IllegalArgumentException("Room not found"));
         room.incrementParticipantCount();
 

--- a/backend/src/main/java/com/pickeat/backend/room/application/ParticipantService.java
+++ b/backend/src/main/java/com/pickeat/backend/room/application/ParticipantService.java
@@ -9,6 +9,7 @@ import com.pickeat.backend.room.domain.repository.RoomRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,9 +18,12 @@ public class ParticipantService {
     private final ParticipantRepository participantRepository;
     private final RoomRepository roomRepository;
 
+    @Transactional
     public ParticipantResponse createParticipant(ParticipantRequest request) {
         Room room = roomRepository.findRoomByCode(UUID.fromString(request.roomCode()))
-                .orElseThrow(() -> new IllegalArgumentException("Room not found with code: " + request.roomCode()));
+                .orElseThrow(() -> new IllegalArgumentException("Room not found"));
+        room.incrementParticipantCount();
+
         Participant participant = new Participant(request.nickname(), room);
         Participant saved = participantRepository.save(participant);
         return ParticipantResponse.from(saved);

--- a/backend/src/main/java/com/pickeat/backend/room/application/RoomService.java
+++ b/backend/src/main/java/com/pickeat/backend/room/application/RoomService.java
@@ -1,11 +1,14 @@
 package com.pickeat.backend.room.application;
 
+import com.pickeat.backend.room.application.dto.ParticipantStateResponse;
 import com.pickeat.backend.room.application.dto.RoomRequest;
 import com.pickeat.backend.room.application.dto.RoomResponse;
 import com.pickeat.backend.room.domain.Location;
 import com.pickeat.backend.room.domain.Radius;
 import com.pickeat.backend.room.domain.Room;
+import com.pickeat.backend.room.domain.repository.ParticipantRepository;
 import com.pickeat.backend.room.domain.repository.RoomRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +17,7 @@ import org.springframework.stereotype.Service;
 public class RoomService {
 
     private final RoomRepository roomRepository;
+    private final ParticipantRepository participantRepository;
 
     public RoomResponse createRoom(RoomRequest request) {
         Room room = new Room(
@@ -24,5 +28,13 @@ public class RoomService {
 
         Room saved = roomRepository.save(room);
         return RoomResponse.from(saved);
+    }
+
+    public ParticipantStateResponse getParticipantStateSummary(String roomCode) {
+        Room room = roomRepository.findByCode(UUID.fromString(roomCode))
+                .orElseThrow(() -> new IllegalArgumentException("Room not found"));
+        int eliminatedCount = participantRepository.countByRoomIdAndIsEliminationCompletedTrue(
+                room.getId());
+        return ParticipantStateResponse.of(room.getParticipantCount(), eliminatedCount);
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/room/application/dto/ParticipantRequest.java
+++ b/backend/src/main/java/com/pickeat/backend/room/application/dto/ParticipantRequest.java
@@ -1,0 +1,5 @@
+package com.pickeat.backend.room.application.dto;
+
+public record ParticipantRequest(String nickname, String roomCode) {
+
+}

--- a/backend/src/main/java/com/pickeat/backend/room/application/dto/ParticipantResponse.java
+++ b/backend/src/main/java/com/pickeat/backend/room/application/dto/ParticipantResponse.java
@@ -1,0 +1,14 @@
+package com.pickeat.backend.room.application.dto;
+
+import com.pickeat.backend.room.domain.Participant;
+
+public record ParticipantResponse(long id, String nickname, String roomCode) {
+
+    public static ParticipantResponse from(Participant participant) {
+        return new ParticipantResponse(
+                participant.getId(),
+                participant.getNickname(),
+                participant.getRoom().getCode().toString()
+        );
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/room/application/dto/ParticipantStateResponse.java
+++ b/backend/src/main/java/com/pickeat/backend/room/application/dto/ParticipantStateResponse.java
@@ -1,0 +1,8 @@
+package com.pickeat.backend.room.application.dto;
+
+public record ParticipantStateResponse(int totalParticipants, int readyParticipants) {
+
+    public static ParticipantStateResponse of(int totalParticipants, int readyParticipants) {
+        return new ParticipantStateResponse(totalParticipants, readyParticipants);
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/room/domain/Participant.java
+++ b/backend/src/main/java/com/pickeat/backend/room/domain/Participant.java
@@ -1,0 +1,33 @@
+package com.pickeat.backend.room.domain;
+
+import com.pickeat.backend.global.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Participant extends BaseEntity {
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private Boolean isEliminationCompleted = false;
+
+    @ManyToOne
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    public Participant(String nickname, Room room) {
+        this.nickname = nickname;
+        this.room = room;
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/room/domain/Room.java
+++ b/backend/src/main/java/com/pickeat/backend/room/domain/Room.java
@@ -39,4 +39,8 @@ public class Room extends BaseEntity {
     public void incrementParticipantCount() {
         this.participantCount++;
     }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
 }

--- a/backend/src/main/java/com/pickeat/backend/room/domain/Room.java
+++ b/backend/src/main/java/com/pickeat/backend/room/domain/Room.java
@@ -35,4 +35,8 @@ public class Room extends BaseEntity {
         this.radius = radius;
         this.code = UUID.randomUUID();
     }
+
+    public void incrementParticipantCount() {
+        this.participantCount++;
+    }
 }

--- a/backend/src/main/java/com/pickeat/backend/room/domain/repository/ParticipantRepository.java
+++ b/backend/src/main/java/com/pickeat/backend/room/domain/repository/ParticipantRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
 
+    int countByRoomIdAndIsEliminationCompletedTrue(Long roomId);
 }

--- a/backend/src/main/java/com/pickeat/backend/room/domain/repository/ParticipantRepository.java
+++ b/backend/src/main/java/com/pickeat/backend/room/domain/repository/ParticipantRepository.java
@@ -1,0 +1,8 @@
+package com.pickeat.backend.room.domain.repository;
+
+import com.pickeat.backend.room.domain.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+
+}

--- a/backend/src/main/java/com/pickeat/backend/room/domain/repository/RoomRepository.java
+++ b/backend/src/main/java/com/pickeat/backend/room/domain/repository/RoomRepository.java
@@ -1,8 +1,11 @@
 package com.pickeat.backend.room.domain.repository;
 
 import com.pickeat.backend.room.domain.Room;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
+    Optional<Room> findRoomByCode(UUID uuid);
 }

--- a/backend/src/main/java/com/pickeat/backend/room/domain/repository/RoomRepository.java
+++ b/backend/src/main/java/com/pickeat/backend/room/domain/repository/RoomRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
-    Optional<Room> findRoomByCode(UUID uuid);
+    Optional<Room> findByCode(UUID uuid);
+
 }

--- a/backend/src/main/java/com/pickeat/backend/room/ui/ParticipantController.java
+++ b/backend/src/main/java/com/pickeat/backend/room/ui/ParticipantController.java
@@ -1,0 +1,32 @@
+package com.pickeat.backend.room.ui;
+
+import com.pickeat.backend.room.application.ParticipantService;
+import com.pickeat.backend.room.application.dto.ParticipantRequest;
+import com.pickeat.backend.room.application.dto.ParticipantResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/participants")
+@RequiredArgsConstructor
+public class ParticipantController {
+
+    private final ParticipantService participantService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ParticipantResponse createParticipant(@RequestBody ParticipantRequest request,
+                                                 HttpServletResponse response) {
+        ParticipantResponse participant = participantService.createParticipant(request);
+
+        String location = "/api/v1/participants/" + participant.id();
+        response.setHeader("Location", location);
+        return participant;
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/room/ui/RoomController.java
+++ b/backend/src/main/java/com/pickeat/backend/room/ui/RoomController.java
@@ -1,9 +1,12 @@
 package com.pickeat.backend.room.ui;
 
 import com.pickeat.backend.room.application.RoomService;
+import com.pickeat.backend.room.application.dto.ParticipantStateResponse;
 import com.pickeat.backend.room.application.dto.RoomRequest;
 import com.pickeat.backend.room.application.dto.RoomResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,4 +24,8 @@ public class RoomController {
         return roomService.createRoom(request);
     }
 
+    @GetMapping("/{roomCode}/participants/state")
+    public ParticipantStateResponse getParticipantStateSummary(@PathVariable String roomCode) {
+        return roomService.getParticipantStateSummary(roomCode);
+    }
 }

--- a/backend/src/main/java/com/pickeat/backend/room/ui/RoomController.java
+++ b/backend/src/main/java/com/pickeat/backend/room/ui/RoomController.java
@@ -6,6 +6,7 @@ import com.pickeat.backend.room.application.dto.RoomRequest;
 import com.pickeat.backend.room.application.dto.RoomResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,5 +28,10 @@ public class RoomController {
     @GetMapping("/{roomCode}/participants/state")
     public ParticipantStateResponse getParticipantStateSummary(@PathVariable String roomCode) {
         return roomService.getParticipantStateSummary(roomCode);
+    }
+
+    @PatchMapping("/{roomCode}/deactivate")
+    public void createRoom(@PathVariable String roomCode) {
+        roomService.deactivateRoom(roomCode);
     }
 }


### PR DESCRIPTION
## Issue Number
#29 

## As-Is
참가자 엔티티 설정 및 관련 api 구현


## To-Be

- 참가자 생성
- 참가자에 의한 방 조기 종료
- 참가자 인원 수 조회에 기반한 방의 총 인원과 소거 완료된 인원 조회


## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
