### PR TITLE
[Hotfix] DTO 필드 타입 Nullable로 변경 및 위치 정보 보호처리 로직 추가

### DIFF
--- a/backend/src/main/java/com/pickeat/backend/restaurant/application/dto/response/RestaurantResponse.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/application/dto/response/RestaurantResponse.java
@@ -21,7 +21,7 @@ public record RestaurantResponse(
         List<String> tags,
 
         @Schema(description = "중심지로부터의 거리 (미터)", example = "150")
-        int distance,
+        Integer distance,
 
         @Schema(description = "장소 URL", example = "https://place.map.kakao.com/12345")
         String placeUrl,
@@ -30,16 +30,16 @@ public record RestaurantResponse(
         String roadAddressName,
 
         @Schema(description = "좋아요 수", example = "3")
-        int likeCount,
+        Integer likeCount,
 
         @Schema(description = "소거 여부", example = "false")
         boolean isExcluded,
 
         @Schema(description = "식당 위치의 x 좌표 (경도)", example = "37.5670")
-        double x,
+        Double x,
 
         @Schema(description = "식당 위치의 y 좌표 (위도)", example = "126.9785")
-        double y,
+        Double y,
 
         @Schema(description = "사진 url들")
         List<String> pictureUrls,
@@ -62,13 +62,30 @@ public record RestaurantResponse(
                 restaurant.getRoadAddressName(),
                 restaurant.getLikeCount(),
                 restaurant.getIsExcluded(),
-                restaurant.getLocation().getX(),
-                restaurant.getLocation().getY(),
+                getLocationX(restaurant),
+                getLocationY(restaurant),
                 parsePictureUrls(restaurant.getPictureUrls()),
                 restaurant.getType(),
                 isLiked);
     }
 
+
+    private static Double getLocationX(Restaurant restaurant) {
+        if (restaurant.getLocation() != null) {
+            return restaurant.getLocation().getX();
+        }
+
+        return null;
+    }
+
+    private static Double getLocationY(Restaurant restaurant) {
+        if (restaurant.getLocation() != null) {
+            return restaurant.getLocation().getY();
+        }
+
+        return null;
+    }
+    
     private static List<String> parseTags(String tags) {
         if (tags == null || tags.isBlank()) {
             return List.of();

--- a/backend/src/main/java/com/pickeat/backend/restaurant/application/dto/response/RestaurantResultResponse.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/application/dto/response/RestaurantResultResponse.java
@@ -20,7 +20,7 @@ public record RestaurantResultResponse(
         List<String> tags,
 
         @Schema(description = "중심지로부터의 거리 (미터)", example = "150")
-        int distance,
+        Integer distance,
 
         @Schema(description = "장소 URL", example = "https://place.map.kakao.com/12345")
         String placeUrl,
@@ -32,10 +32,10 @@ public record RestaurantResultResponse(
         int likeCount,
 
         @Schema(description = "식당 위치의 x 좌표 (경도)", example = "37.5670")
-        double x,
+        Double x,
 
         @Schema(description = "식당 위치의 y 좌표 (위도)", example = "126.9785")
-        double y,
+        Double y,
 
         @Schema(description = "사진 url들")
         List<String> pictureUrls,
@@ -55,8 +55,8 @@ public record RestaurantResultResponse(
                 restaurant.getPlaceUrl(),
                 restaurant.getRoadAddressName(),
                 restaurant.getLikeCount(),
-                restaurant.getLocation().getX(),
-                restaurant.getLocation().getY(),
+                getLocationX(restaurant),
+                getLocationY(restaurant),
                 parsePictureUrls(restaurant.getPictureUrls()),
                 restaurant.getType());
     }
@@ -67,6 +67,22 @@ public record RestaurantResultResponse(
                 .toList();
     }
 
+
+    private static Double getLocationX(Restaurant restaurant) {
+        if (restaurant.getLocation() != null) {
+            return restaurant.getLocation().getX();
+        }
+
+        return null;
+    }
+
+    private static Double getLocationY(Restaurant restaurant) {
+        if (restaurant.getLocation() != null) {
+            return restaurant.getLocation().getY();
+        }
+
+        return null;
+    }
 
     private static List<String> parseTags(String tags) {
         if (tags == null || tags.isBlank()) {

--- a/backend/src/main/java/com/pickeat/backend/restaurant/ui/api/RestaurantApiSpec.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/ui/api/RestaurantApiSpec.java
@@ -55,7 +55,7 @@ public interface RestaurantApiSpec {
 
 
     @Operation(
-            summary = "위 목록 기반 식당 목록 생성",
+            summary = "위시 목록 기반 식당 목록 생성",
             description = "사용자의 위 목록에 있는 식당들을 기반으로 식당 목록을 생성하여 픽잇에 추가합니다.",
             operationId = "createRestaurantsByWish",
             requestBody = @RequestBody(


### PR DESCRIPTION
#162 


## As-Is
<!-- 문제 상황 정의 -->
기존 식당 응답 Dto의 필드가 모두 윈시값이었음. 따라서 null이 들어올 경우 변환 과정에서 NPE 발생

## To-Be
<!-- 변경 사항 -->
응답 Dto 필드를 Wrapper로 변경

## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
