### PR TITLE
[Refactor] 위시 목록 리스트 조회 api 기능 개선

### DIFF
--- a/backend/src/main/java/com/pickeat/backend/wish/application/WishService.java
+++ b/backend/src/main/java/com/pickeat/backend/wish/application/WishService.java
@@ -60,7 +60,7 @@ public class WishService {
         }
         //TODO: 양방향 조회의 쿼리 확인 후 최적화 필요하면 wishRepository.findAllByWishList  (2025-08-6, 수, 10:8)
         List<Wish> wishes = wishList.getWishes();
-        wishes.sort(Comparator.comparing(Wish::getCreatedAt));
+        wishes.sort(Comparator.comparing(Wish::getCreatedAt).reversed());
         return WishResponse.from(wishes);
     }
 
@@ -69,7 +69,7 @@ public class WishService {
         validateIsPublicWishList(wishList);
         //TODO: 양방향 조회의 쿼리 확인 후 최적화 필요하면 wishRepository.findAllByWishList  (2025-08-6, 수, 10:8)
         List<Wish> wishes = wishList.getWishes();
-        wishes.sort(Comparator.comparing(Wish::getCreatedAt));
+        wishes.sort(Comparator.comparing(Wish::getCreatedAt).reversed());
         return WishResponse.from(wishes);
     }
 

--- a/backend/src/main/java/com/pickeat/backend/wish/application/WishService.java
+++ b/backend/src/main/java/com/pickeat/backend/wish/application/WishService.java
@@ -10,6 +10,7 @@ import com.pickeat.backend.wish.domain.Wish;
 import com.pickeat.backend.wish.domain.WishList;
 import com.pickeat.backend.wish.domain.repository.WishListRepository;
 import com.pickeat.backend.wish.domain.repository.WishRepository;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -56,7 +57,9 @@ public class WishService {
         WishList wishList = getWishList(wishListId);
         validateUserAccessToRoom(wishList.getRoomId(), userId);
         //TODO: 양방향 조회의 쿼리 확인 후 최적화 필요하면 wishRepository.findAllByWishList  (2025-08-6, 수, 10:8)
-        return WishResponse.from(wishList.getWishes());
+        List<Wish> wishes = wishList.getWishes();
+        wishes.sort(Comparator.comparing(Wish::getCreatedAt));
+        return WishResponse.from(wishes);
     }
 
     public List<WishResponse> getWishesFromPublicWishList(Long wishListId) {

--- a/backend/src/main/java/com/pickeat/backend/wish/application/WishService.java
+++ b/backend/src/main/java/com/pickeat/backend/wish/application/WishService.java
@@ -66,7 +66,9 @@ public class WishService {
         WishList wishList = getWishList(wishListId);
         validateIsPublicWishList(wishList);
         //TODO: 양방향 조회의 쿼리 확인 후 최적화 필요하면 wishRepository.findAllByWishList  (2025-08-6, 수, 10:8)
-        return WishResponse.from(wishList.getWishes());
+        List<Wish> wishes = wishList.getWishes();
+        wishes.sort(Comparator.comparing(Wish::getCreatedAt));
+        return WishResponse.from(wishes);
     }
 
     private WishList getWishList(Long wishListId) {

--- a/backend/src/main/java/com/pickeat/backend/wish/application/WishService.java
+++ b/backend/src/main/java/com/pickeat/backend/wish/application/WishService.java
@@ -55,7 +55,9 @@ public class WishService {
 
     public List<WishResponse> getWishes(Long wishListId, Long userId) {
         WishList wishList = getWishList(wishListId);
-        validateUserAccessToRoom(wishList.getRoomId(), userId);
+        if (!wishList.getIsPublic()) {
+            validateUserAccessToRoom(wishList.getRoomId(), userId);
+        }
         //TODO: 양방향 조회의 쿼리 확인 후 최적화 필요하면 wishRepository.findAllByWishList  (2025-08-6, 수, 10:8)
         List<Wish> wishes = wishList.getWishes();
         wishes.sort(Comparator.comparing(Wish::getCreatedAt));

--- a/backend/src/test/java/com/pickeat/backend/wish/application/WishServiceTest.java
+++ b/backend/src/test/java/com/pickeat/backend/wish/application/WishServiceTest.java
@@ -17,6 +17,7 @@ import com.pickeat.backend.wish.application.dto.response.WishResponse;
 import com.pickeat.backend.wish.domain.Wish;
 import com.pickeat.backend.wish.domain.WishList;
 import com.pickeat.backend.wish.domain.repository.WishRepository;
+import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -144,6 +145,34 @@ class WishServiceTest {
             assertThat(response)
                     .extracting(WishResponse::id)
                     .containsExactlyInAnyOrderElementsOf(actualWishIds);
+        }
+
+        @Test
+        void 조회된_위시들은_기본적으로_생성순으로_정렬() {
+            // given
+            User user = entityManager.persist(UserFixture.create());
+            Room room = entityManager.persist(RoomFixture.create());
+            RoomUser roomUser = entityManager.persist(new RoomUser(room, user));
+
+            WishList wishList = entityManager.persist(WishListFixture.createPrivate(room.getId()));
+            List<Wish> wishes = List.of(
+                    entityManager.persist(WishFixture.create(wishList)),
+                    entityManager.persist(WishFixture.create(wishList)),
+                    entityManager.persist(WishFixture.create(wishList)));
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            List<WishResponse> response = wishService.getWishes(wishList.getId(), user.getId());
+
+            // then
+            List<Long> sortedWishIds = wishes.stream()
+                    .sorted(Comparator.comparing(Wish::getCreatedAt))
+                    .map(Wish::getId).toList();
+            assertThat(response)
+                    .extracting(WishResponse::id)
+                    .containsExactlyElementsOf(sortedWishIds);
         }
 
         @Test

--- a/backend/src/test/java/com/pickeat/backend/wish/application/WishServiceTest.java
+++ b/backend/src/test/java/com/pickeat/backend/wish/application/WishServiceTest.java
@@ -223,6 +223,31 @@ class WishServiceTest {
         }
 
         @Test
+        void 조회되는_위시는_기본적으로_생성순으로_정렬() {
+            // given
+            Room room = entityManager.persist(RoomFixture.create());
+            WishList wishList = entityManager.persist(WishListFixture.createPublic(room.getId()));
+            List<Wish> wishes = List.of(
+                    entityManager.persist(WishFixture.create(wishList)),
+                    entityManager.persist(WishFixture.create(wishList)),
+                    entityManager.persist(WishFixture.create(wishList)));
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            List<WishResponse> responses = wishService.getWishesFromPublicWishList(wishList.getId());
+
+            // then
+            List<Long> sortedWishIds = wishes.stream()
+                    .sorted(Comparator.comparing(Wish::getCreatedAt))
+                    .map(Wish::getId).toList();
+            assertThat(responses)
+                    .extracting(WishResponse::id)
+                    .containsExactlyInAnyOrderElementsOf(sortedWishIds);
+        }
+
+        @Test
         void 위시리스트가_존재하지_않는_경우_예외_발생() {
             // when & then
             assertThatThrownBy(() -> wishService.getWishesFromPublicWishList(1L))

--- a/backend/src/test/java/com/pickeat/backend/wish/application/WishServiceTest.java
+++ b/backend/src/test/java/com/pickeat/backend/wish/application/WishServiceTest.java
@@ -168,7 +168,7 @@ class WishServiceTest {
 
             // then
             List<Long> sortedWishIds = wishes.stream()
-                    .sorted(Comparator.comparing(Wish::getCreatedAt))
+                    .sorted(Comparator.comparing(Wish::getCreatedAt).reversed())
                     .map(Wish::getId).toList();
             assertThat(response)
                     .extracting(WishResponse::id)
@@ -264,7 +264,7 @@ class WishServiceTest {
 
             // then
             List<Long> sortedWishIds = wishes.stream()
-                    .sorted(Comparator.comparing(Wish::getCreatedAt))
+                    .sorted(Comparator.comparing(Wish::getCreatedAt).reversed())
                     .map(Wish::getId).toList();
             assertThat(responses)
                     .extracting(WishResponse::id)

--- a/backend/src/test/java/com/pickeat/backend/wish/application/WishServiceTest.java
+++ b/backend/src/test/java/com/pickeat/backend/wish/application/WishServiceTest.java
@@ -194,6 +194,30 @@ class WishServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(ErrorCode.WISH_ACCESS_DENIED.getMessage());
         }
+
+        @Test
+        void 공용_위시는_검증없이_조회() {
+            // given
+            User user = entityManager.persist(UserFixture.create());
+            Room room = entityManager.persist(RoomFixture.create());
+            WishList publicWishList = entityManager.persist(WishListFixture.createPublic(room.getId()));
+            List<Wish> wishes = List.of(
+                    entityManager.persist(WishFixture.create(publicWishList)),
+                    entityManager.persist(WishFixture.create(publicWishList)),
+                    entityManager.persist(WishFixture.create(publicWishList)));
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            List<WishResponse> response = wishService.getWishes(publicWishList.getId(), user.getId());
+
+            // then
+            List<Long> actualWishIds = wishes.stream().map(Wish::getId).toList();
+            assertThat(response)
+                    .extracting(WishResponse::id)
+                    .containsExactlyInAnyOrderElementsOf(actualWishIds);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Issue Number
#195 

## As-Is
<!-- 문제 상황 정의 -->
- 위시리스트의 위시를 조회할 때, 조회되는 위시들이 정렬되어 있지않음
- 위시리스트의 위시 조회 API의 경우, 공개 위시리스트의 위시들은 조회가 불가능

## To-Be
<!-- 변경 사항 -->
- 위시리스트의 위시를 조회할 때, 조회되는 위시들이 정렬되도록 수정
- 위시리스트의 위시 조회 API의 경우, 공개 위시리스트도 조회되도록 수정


## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
close #195 