### PR TITLE
[Feature] 픽잇 종료 구현

### DIFF
--- a/frontend/src/apis/pickeat.ts
+++ b/frontend/src/apis/pickeat.ts
@@ -3,7 +3,6 @@ import { getLatLngByAddress } from '@domains/pickeat/utils/convertAddress';
 import { joinAsPath } from '@utils/createUrl';
 
 import { apiClient } from './apiClient';
-import { RestaurantResponse } from './restaurant';
 
 export type PickeatType = {
   id: number;
@@ -34,11 +33,36 @@ type ParticipantsResponse = {
   eliminatedParticipants: number;
 };
 
-export type PickeatResult = {
-  type: 'WISH' | 'LOCATION';
+type PickeatResultResponse = {
+  id: number;
   name: string;
+  category: string;
+  tags: string[];
+  distance: number;
+  placeUrl: string;
+  roadAddressName: string;
+  likeCount: number;
+  x: number;
+  y: number;
+  pictureUrls: string[];
+  type: 'WISH' | 'LOCATION';
+  hasEqualLike: boolean;
+};
+
+export type PickeatResult = {
+  id: number;
+  name: string;
+  category: string;
+  tags: string[];
+  distance: number;
   placeUrl: string | null;
-  pictureUrls: string[] | [];
+  roadAddressName: string;
+  likeCount: number;
+  x: number;
+  y: number;
+  pictureUrls: string[];
+  type: 'WISH' | 'LOCATION';
+  hasEqualLike: boolean;
 };
 
 const convertResponseToPickeatDetail = async (
@@ -50,12 +74,21 @@ const convertResponseToPickeatDetail = async (
 });
 
 const convertResponseToResult = async (
-  data: RestaurantResponse
+  data: PickeatResultResponse
 ): Promise<PickeatResult> => ({
-  type: data.type,
+  id: data.id,
   name: data.name,
+  category: data.category,
+  tags: data.tags,
+  distance: data.distance,
   placeUrl: data.placeUrl,
+  roadAddressName: data.roadAddressName,
+  likeCount: data.likeCount,
+  x: data.x,
+  y: data.y,
   pictureUrls: data.pictureUrls,
+  type: data.type,
+  hasEqualLike: data.hasEqualLike,
 });
 
 const BASE_PATH = 'pickeats';
@@ -110,7 +143,13 @@ export const pickeat = {
   },
   getResult: async (pickeatCode: string): Promise<PickeatResult | null> => {
     const url = joinAsPath(BASE_PATH, pickeatCode, 'result');
-    const response = await apiClient.get<RestaurantResponse>(url);
+    const response = await apiClient.get<PickeatResultResponse>(url);
+    if (response) return convertResponseToResult(response);
+    return null;
+  },
+  postResult: async (pickeatCode: string): Promise<PickeatResult | null> => {
+    const url = joinAsPath(BASE_PATH, pickeatCode, 'result');
+    const response = await apiClient.post<PickeatResultResponse>(url);
     if (response) return convertResponseToResult(response);
     return null;
   },

--- a/frontend/src/apis/pickeat.ts
+++ b/frontend/src/apis/pickeat.ts
@@ -65,6 +65,10 @@ export type PickeatResult = {
   hasEqualLike: boolean;
 };
 
+export type PickeatStateResponse = {
+  isActive: boolean;
+};
+
 const convertResponseToPickeatDetail = async (
   data: PickeatResponse
 ): Promise<PickeatType> => ({
@@ -145,6 +149,14 @@ export const pickeat = {
     const url = joinAsPath(BASE_PATH, pickeatCode, 'result');
     const response = await apiClient.get<PickeatResultResponse>(url);
     if (response) return convertResponseToResult(response);
+    return null;
+  },
+  getPickeatState: async (
+    pickeatCode: string
+  ): Promise<PickeatStateResponse | null> => {
+    const url = joinAsPath(BASE_PATH, pickeatCode, 'state');
+    const response = await apiClient.get<PickeatStateResponse>(url);
+    if (response) return response;
     return null;
   },
   postResult: async (pickeatCode: string): Promise<PickeatResult | null> => {

--- a/frontend/src/domains/matchResult/components/PickeatDecisionInfo.tsx
+++ b/frontend/src/domains/matchResult/components/PickeatDecisionInfo.tsx
@@ -10,23 +10,31 @@ function PickeatDecisionInfo() {
   const [hasTie, setHasTie] = useState(false);
 
   useEffect(() => {
-    restaurants.get(pickeatCode).then(restaurantsData => {
-      const maxLikeCount = Math.max(
-        ...restaurantsData.map(restaurant => restaurant.likeCount)
-      );
-      const topRestaurants = restaurantsData.filter(
-        restaurant => restaurant.likeCount === maxLikeCount
-      );
-      setHasTie(topRestaurants.length > 1);
-    });
+    const fetchRestaurants = async () => {
+      try {
+        const restaurantsData = await restaurants.get(pickeatCode);
+        const maxLikeCount = Math.max(
+          ...restaurantsData.map(restaurant => restaurant.likeCount)
+        );
+        const topRestaurants = restaurantsData.filter(
+          restaurant => restaurant.likeCount === maxLikeCount
+        );
+        setHasTie(topRestaurants.length > 1);
+      } catch {
+        alert('현재 통신이 원활하지 않습니다');
+      }
+    };
+
+    fetchRestaurants();
   }, []);
 
   return (
     <S.Container>
-      종료 시점에 좋아요가 제일 많은 식당으로 결정됩니다
+      현재 좋아요가 제일 많은 식당으로 결정됩니다
       {hasTie && (
         <S.Description>
-          현재 동점이 있어 랜덤으로 결과가 결정됩니다
+          동점으로 인해 최대 득표수를 기록한 식당들 중 하나가 무작위로
+          결정됩니다.
         </S.Description>
       )}
     </S.Container>

--- a/frontend/src/domains/matchResult/components/PickeatDecisionInfo.tsx
+++ b/frontend/src/domains/matchResult/components/PickeatDecisionInfo.tsx
@@ -38,11 +38,13 @@ export default PickeatDecisionInfo;
 const S = {
   Container: styled.div`
     display: flex;
-    gap: ${({ theme }) => theme.GAP.level5};
+    gap: ${({ theme }) => theme.GAP.level2};
     flex-direction: column;
+    justify-content: center;
+    align-items: center;
   `,
   Description: styled.p`
-    color: ${({ theme }) => theme.PALETTE.gray[60]};
+    color: ${({ theme }) => theme.PALETTE.gray[40]};
     font: ${({ theme }) => theme.FONTS.body.small};
   `,
 };

--- a/frontend/src/domains/matchResult/components/PickeatDecisionInfo.tsx
+++ b/frontend/src/domains/matchResult/components/PickeatDecisionInfo.tsx
@@ -1,0 +1,48 @@
+import { restaurants } from '@apis/restaurants';
+
+import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router';
+
+function PickeatDecisionInfo() {
+  const [searchParams] = useSearchParams();
+  const pickeatCode = searchParams.get('code') ?? '';
+  const [hasTie, setHasTie] = useState(false);
+
+  useEffect(() => {
+    restaurants.get(pickeatCode).then(restaurantsData => {
+      const maxLikeCount = Math.max(
+        ...restaurantsData.map(restaurant => restaurant.likeCount)
+      );
+      const topRestaurants = restaurantsData.filter(
+        restaurant => restaurant.likeCount === maxLikeCount
+      );
+      setHasTie(topRestaurants.length > 1);
+    });
+  }, []);
+
+  return (
+    <S.Container>
+      종료 시점에 좋아요가 제일 많은 식당으로 결정됩니다
+      {hasTie && (
+        <S.Description>
+          현재 동점이 있어 랜덤으로 결과가 결정됩니다
+        </S.Description>
+      )}
+    </S.Container>
+  );
+}
+
+export default PickeatDecisionInfo;
+
+const S = {
+  Container: styled.div`
+    display: flex;
+    gap: ${({ theme }) => theme.GAP.level5};
+    flex-direction: column;
+  `,
+  Description: styled.p`
+    color: ${({ theme }) => theme.PALETTE.gray[60]};
+    font: ${({ theme }) => theme.FONTS.body.small};
+  `,
+};

--- a/frontend/src/domains/matchResult/components/PickeatEndButton.tsx
+++ b/frontend/src/domains/matchResult/components/PickeatEndButton.tsx
@@ -1,0 +1,62 @@
+import Button from '@components/actions/Button';
+import Modal from '@components/modal/Modal';
+import { useModal } from '@components/modal/useModal';
+
+import { useGA } from '@hooks/useGA';
+
+import styled from '@emotion/styled';
+
+function PickeatEndButton() {
+  const {
+    opened,
+    mounted,
+    handleOpenModal,
+    handleCloseModal,
+    handleUnmountModal,
+  } = useModal();
+
+  const endPickeat = () => {
+    handleCloseModal();
+    useGA().useGAEventTrigger({
+      action: 'click',
+      category: 'button',
+      label: '결과 페이지 이동 버튼',
+      value: 1,
+    });
+  };
+
+  return (
+    <>
+      <Button text="투표 종료" size="md" onClick={handleOpenModal} />
+      <Modal
+        opened={opened}
+        mounted={mounted}
+        onUnmount={handleUnmountModal}
+        onClose={handleCloseModal}
+      >
+        <S.Container>
+          정말 종료하시겠습니까?
+          <S.Wrapper>
+            <Button text="취소" color="gray" onClick={handleUnmountModal} />
+            <Button text="종료" onClick={endPickeat} />
+          </S.Wrapper>
+        </S.Container>
+      </Modal>
+    </>
+  );
+}
+
+export default PickeatEndButton;
+
+const S = {
+  Container: styled.div`
+    display: flex;
+    gap: ${({ theme }) => theme.GAP.level5};
+    flex-direction: column;
+  `,
+  Wrapper: styled.div`
+    display: flex;
+    align-items: center;
+    gap: ${({ theme }) => theme.GAP.level5};
+  `,
+};

--- a/frontend/src/domains/matchResult/components/PickeatEndButton.tsx
+++ b/frontend/src/domains/matchResult/components/PickeatEndButton.tsx
@@ -2,9 +2,14 @@ import Button from '@components/actions/Button';
 import Modal from '@components/modal/Modal';
 import { useModal } from '@components/modal/useModal';
 
+import { pickeat } from '@apis/pickeat';
+
 import { useGA } from '@hooks/useGA';
 
+import { generateRouterPath } from '@routes/routePath';
+
 import styled from '@emotion/styled';
+import { useNavigate, useSearchParams } from 'react-router';
 
 function PickeatEndButton() {
   const {
@@ -15,7 +20,12 @@ function PickeatEndButton() {
     handleUnmountModal,
   } = useModal();
 
-  const endPickeat = () => {
+  const [searchParams] = useSearchParams();
+  const pickeatCode = searchParams.get('code') ?? '';
+
+  const navigate = useNavigate();
+
+  const endPickeat = async () => {
     handleCloseModal();
     useGA().useGAEventTrigger({
       action: 'click',
@@ -23,6 +33,12 @@ function PickeatEndButton() {
       label: '결과 페이지 이동 버튼',
       value: 1,
     });
+    try {
+      await pickeat.postResult(pickeatCode);
+      navigate(generateRouterPath.matchResult(pickeatCode));
+    } catch {
+      return alert('픽잇 결과를 가져오는 데 실패했습니다.');
+    }
   };
 
   return (

--- a/frontend/src/domains/matchResult/components/PickeatEndButton.tsx
+++ b/frontend/src/domains/matchResult/components/PickeatEndButton.tsx
@@ -2,14 +2,9 @@ import Button from '@components/actions/Button';
 import Modal from '@components/modal/Modal';
 import { useModal } from '@components/modal/useModal';
 
-import { pickeat } from '@apis/pickeat';
-
 import { useGA } from '@hooks/useGA';
 
-import { generateRouterPath } from '@routes/routePath';
-
-import styled from '@emotion/styled';
-import { useNavigate, useSearchParams } from 'react-router';
+import PickeatEndConfirm from './PickeatEndConfirm';
 
 function PickeatEndButton() {
   const {
@@ -20,59 +15,32 @@ function PickeatEndButton() {
     handleUnmountModal,
   } = useModal();
 
-  const [searchParams] = useSearchParams();
-  const pickeatCode = searchParams.get('code') ?? '';
-
-  const navigate = useNavigate();
-
-  const endPickeat = async () => {
-    handleCloseModal();
+  const openEndModal = () => {
+    handleOpenModal();
     useGA().useGAEventTrigger({
       action: 'click',
       category: 'button',
-      label: '결과 페이지 이동 버튼',
+      label: '투표 종료 모달 버튼',
       value: 1,
     });
-    try {
-      await pickeat.postResult(pickeatCode);
-      navigate(generateRouterPath.matchResult(pickeatCode));
-    } catch {
-      return alert('픽잇 결과를 가져오는 데 실패했습니다.');
-    }
   };
 
   return (
     <>
-      <Button text="투표 종료" size="md" onClick={handleOpenModal} />
+      <Button text="투표 종료" size="md" onClick={openEndModal} />
       <Modal
         opened={opened}
         mounted={mounted}
         onUnmount={handleUnmountModal}
         onClose={handleCloseModal}
       >
-        <S.Container>
-          정말 종료하시겠습니까?
-          <S.Wrapper>
-            <Button text="취소" color="gray" onClick={handleUnmountModal} />
-            <Button text="종료" onClick={endPickeat} />
-          </S.Wrapper>
-        </S.Container>
+        <PickeatEndConfirm
+          onCancel={handleUnmountModal}
+          onConfirm={handleUnmountModal}
+        />
       </Modal>
     </>
   );
 }
 
 export default PickeatEndButton;
-
-const S = {
-  Container: styled.div`
-    display: flex;
-    gap: ${({ theme }) => theme.GAP.level5};
-    flex-direction: column;
-  `,
-  Wrapper: styled.div`
-    display: flex;
-    align-items: center;
-    gap: ${({ theme }) => theme.GAP.level5};
-  `,
-};

--- a/frontend/src/domains/matchResult/components/PickeatEndConfirm.tsx
+++ b/frontend/src/domains/matchResult/components/PickeatEndConfirm.tsx
@@ -7,7 +7,6 @@ import { useGA } from '@hooks/useGA';
 import { generateRouterPath } from '@routes/routePath';
 
 import styled from '@emotion/styled';
-import { Suspense } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 
 import PickeatDecisionInfo from './PickeatDecisionInfo';
@@ -44,12 +43,8 @@ function PickeatEndConfirm({
 
   return (
     <S.Container>
-      <S.Container>
-        정말 종료하시겠습니까?
-        <Suspense>
-          <PickeatDecisionInfo />
-        </Suspense>
-      </S.Container>
+      <S.Title>정말 종료하시겠습니까?</S.Title>
+      <PickeatDecisionInfo />
       <S.Wrapper>
         <Button text="취소" color="gray" onClick={onCancel} />
         <Button text="종료" onClick={endPickeat} />
@@ -65,8 +60,14 @@ const S = {
     display: flex;
     gap: ${({ theme }) => theme.GAP.level5};
     flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  `,
+  Title: styled.p`
+    font: ${({ theme }) => theme.FONTS.heading.medium};
   `,
   Wrapper: styled.div`
+    width: 100%;
     display: flex;
     align-items: center;
     gap: ${({ theme }) => theme.GAP.level5};

--- a/frontend/src/domains/matchResult/components/PickeatEndConfirm.tsx
+++ b/frontend/src/domains/matchResult/components/PickeatEndConfirm.tsx
@@ -1,0 +1,74 @@
+import Button from '@components/actions/Button';
+
+import { pickeat } from '@apis/pickeat';
+
+import { useGA } from '@hooks/useGA';
+
+import { generateRouterPath } from '@routes/routePath';
+
+import styled from '@emotion/styled';
+import { Suspense } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+
+import PickeatDecisionInfo from './PickeatDecisionInfo';
+
+type Props = {
+  onCancel?: () => void;
+  onConfirm?: () => void;
+};
+
+function PickeatEndConfirm({
+  onCancel = () => {},
+  onConfirm = () => {},
+}: Props) {
+  const [searchParams] = useSearchParams();
+  const pickeatCode = searchParams.get('code') ?? '';
+
+  const navigate = useNavigate();
+
+  const endPickeat = async () => {
+    onConfirm();
+    useGA().useGAEventTrigger({
+      action: 'click',
+      category: 'button',
+      label: '결과 페이지 이동 버튼',
+      value: 1,
+    });
+    try {
+      await pickeat.postResult(pickeatCode);
+      navigate(generateRouterPath.matchResult(pickeatCode));
+    } catch {
+      return alert('픽잇 결과를 가져오는 데 실패했습니다.');
+    }
+  };
+
+  return (
+    <S.Container>
+      <S.Container>
+        정말 종료하시겠습니까?
+        <Suspense>
+          <PickeatDecisionInfo />
+        </Suspense>
+      </S.Container>
+      <S.Wrapper>
+        <Button text="취소" color="gray" onClick={onCancel} />
+        <Button text="종료" onClick={endPickeat} />
+      </S.Wrapper>
+    </S.Container>
+  );
+}
+
+export default PickeatEndConfirm;
+
+const S = {
+  Container: styled.div`
+    display: flex;
+    gap: ${({ theme }) => theme.GAP.level5};
+    flex-direction: column;
+  `,
+  Wrapper: styled.div`
+    display: flex;
+    align-items: center;
+    gap: ${({ theme }) => theme.GAP.level5};
+  `,
+};

--- a/frontend/src/domains/matchResult/components/PickeatEndConfirm.tsx
+++ b/frontend/src/domains/matchResult/components/PickeatEndConfirm.tsx
@@ -69,7 +69,6 @@ const S = {
   Wrapper: styled.div`
     width: 100%;
     display: flex;
-    align-items: center;
     gap: ${({ theme }) => theme.GAP.level5};
   `,
 };

--- a/frontend/src/domains/matchResult/hooks/usePickeatEndCheck.ts
+++ b/frontend/src/domains/matchResult/hooks/usePickeatEndCheck.ts
@@ -28,5 +28,6 @@ export function usePickeatStateChecker(pickeatCode: string) {
       }
     },
     interval: 3000,
+    immediate: true,
   });
 }

--- a/frontend/src/domains/matchResult/hooks/usePickeatEndCheck.ts
+++ b/frontend/src/domains/matchResult/hooks/usePickeatEndCheck.ts
@@ -1,0 +1,32 @@
+import { pickeat, PickeatStateResponse } from '@apis/pickeat';
+
+import { usePolling } from '@hooks/usePolling';
+
+import { generateRouterPath, ROUTE_PATH } from '@routes/routePath';
+
+import { useNavigate } from 'react-router';
+
+export function usePickeatStateChecker(pickeatCode: string) {
+  const navigate = useNavigate();
+
+  const fetchPickeatState = async (): Promise<PickeatStateResponse | null> => {
+    return await pickeat.getPickeatState(pickeatCode);
+  };
+
+  usePolling<PickeatStateResponse | null>(fetchPickeatState, {
+    setData: data => {
+      if (data?.isActive === false) {
+        navigate(generateRouterPath.matchResult(pickeatCode));
+      }
+    },
+    errorHandler: error => {
+      if (error.message === 'PICKEAT_NOT_FOUND') {
+        alert('종료된 접근입니다.');
+        navigate(ROUTE_PATH.MAIN);
+      } else {
+        console.error('Polling error:', error.message);
+      }
+    },
+    interval: 3000,
+  });
+}

--- a/frontend/src/domains/matchResult/hooks/usePickeatEndCheck.ts
+++ b/frontend/src/domains/matchResult/hooks/usePickeatEndCheck.ts
@@ -14,14 +14,14 @@ export function usePickeatStateChecker(pickeatCode: string) {
   };
 
   usePolling<PickeatStateResponse | null>(fetchPickeatState, {
-    setData: data => {
+    onData: data => {
       if (data?.isActive === false) {
         navigate(generateRouterPath.matchResult(pickeatCode));
       }
     },
     errorHandler: error => {
       if (error.message === 'PICKEAT_NOT_FOUND') {
-        alert('종료된 접근입니다.');
+        alert('해당 픽잇이 종료되었습니다');
         navigate(ROUTE_PATH.MAIN);
       } else {
         console.error('Polling error:', error.message);

--- a/frontend/src/domains/preferRestaurant/components/PreferRestaurantList.tsx
+++ b/frontend/src/domains/preferRestaurant/components/PreferRestaurantList.tsx
@@ -26,6 +26,7 @@ function PreferRestaurantList({ preferRestaurantListPromise }: Props) {
     initialData,
     syncOptimisticLikes
   );
+
   const { itemRefs } = useFlip(restaurantList);
 
   const handleLike = async (id: number) => {

--- a/frontend/src/domains/restaurantExclude/components/restaurantTabList/hooks/useRestaurantsData.ts
+++ b/frontend/src/domains/restaurantExclude/components/restaurantTabList/hooks/useRestaurantsData.ts
@@ -22,7 +22,7 @@ export function useRestaurantsData(initialData: Restaurant[] = []) {
   const fetcher = useCallback(() => restaurants.get(code ?? ''), [code]);
 
   usePolling<Restaurant[]>(fetcher, {
-    setData: handleDataUpdate,
+    onData: handleDataUpdate,
     interval: 3000,
     enabled: !!code,
     errorHandler: error => {

--- a/frontend/src/pages/MatchResult.tsx
+++ b/frontend/src/pages/MatchResult.tsx
@@ -23,7 +23,6 @@ function MatchResult() {
       <S.ResultWrapper>
         <Confetti />
         <S.Title>👏 오늘의 Pick! 👏</S.Title>
-
         <ErrorBoundary>
           <Suspense fallback={<div>로딩중</div>}>
             <Result resultPromise={pickeat.getResult(pickeatCode)} />

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -12,17 +12,19 @@ import { users } from '@apis/users';
 import { ROUTE_PATH } from '@routes/routePath';
 
 import styled from '@emotion/styled';
-import { Suspense } from 'react';
+import { Suspense, useMemo } from 'react';
 import { useNavigate } from 'react-router';
 
 function MyPage() {
   const navigate = useNavigate();
+  const userData = useMemo(() => users.get(), []);
+  const roomsData = useMemo(() => rooms.get(), []);
   return (
     <S.Container>
       <ErrorBoundary>
         <Suspense fallback={<div>로딩중...</div>}>
-          <Profile user={users.get()} />
-          <RoomList roomsData={rooms.get()} />
+          <Profile user={userData} />
+          <RoomList roomsData={roomsData} />
         </Suspense>
       </ErrorBoundary>
       <Button

--- a/frontend/src/pages/PreferRestaurant.tsx
+++ b/frontend/src/pages/PreferRestaurant.tsx
@@ -7,6 +7,7 @@ import Arrow from '@components/assets/icons/Arrow';
 import { HEADER_HEIGHT } from '@components/layouts/Header';
 
 import ErrorBoundary from '@domains/errorBoundary/ErrorBoundary';
+import { usePickeatStateChecker } from '@domains/matchResult/hooks/usePickeatEndCheck';
 
 import { restaurants } from '@apis/restaurants';
 
@@ -21,6 +22,7 @@ function PreferRestaurant() {
   const pickeatCode = searchParams.get('code') ?? '';
 
   const navigate = useNavigate();
+  usePickeatStateChecker(pickeatCode);
 
   return (
     <S.Container>

--- a/frontend/src/pages/PreferRestaurant.tsx
+++ b/frontend/src/pages/PreferRestaurant.tsx
@@ -1,3 +1,4 @@
+import PickeatEndButton from '@domains/matchResult/components/PickeatEndButton';
 import Participant from '@domains/preferRestaurant/components/Participant';
 import PreferRestaurantList from '@domains/preferRestaurant/components/PreferRestaurantList';
 
@@ -8,8 +9,6 @@ import { HEADER_HEIGHT } from '@components/layouts/Header';
 import ErrorBoundary from '@domains/errorBoundary/ErrorBoundary';
 
 import { restaurants } from '@apis/restaurants';
-
-import { useGA } from '@hooks/useGA';
 
 import { generateRouterPath } from '@routes/routePath';
 
@@ -22,16 +21,6 @@ function PreferRestaurant() {
   const pickeatCode = searchParams.get('code') ?? '';
 
   const navigate = useNavigate();
-
-  const handleResultClick = () => {
-    navigate(generateRouterPath.matchResult(pickeatCode));
-    useGA().useGAEventTrigger({
-      action: 'click',
-      category: 'button',
-      label: '결과 페이지 이동 버튼',
-      value: 1,
-    });
-  };
 
   return (
     <S.Container>
@@ -64,13 +53,7 @@ function PreferRestaurant() {
           }
           leftIcon={<Arrow size="sm" direction="left" color={'black'} />}
         />
-        <Button
-          text="결과"
-          color="secondary"
-          size="md"
-          onClick={handleResultClick}
-          rightIcon={<Arrow size="sm" direction="right" color={'black'} />}
-        />
+        <PickeatEndButton />
       </S.Footer>
     </S.Container>
   );

--- a/frontend/src/pages/restaurantExclude/RestaurantExcludePage.tsx
+++ b/frontend/src/pages/restaurantExclude/RestaurantExcludePage.tsx
@@ -3,6 +3,7 @@ import RestaurantExclude from '@domains/restaurantExclude/components/RestaurantE
 import { HEADER_HEIGHT } from '@components/layouts/Header';
 
 import ErrorBoundary from '@domains/errorBoundary/ErrorBoundary';
+import { usePickeatStateChecker } from '@domains/matchResult/hooks/usePickeatEndCheck';
 
 import { restaurants } from '@apis/restaurants';
 
@@ -14,14 +15,17 @@ import TitleArea from './components/TitleArea';
 
 function RestaurantExcludePage() {
   const [searchParams] = useSearchParams();
-  const code = searchParams.get('code') ?? '';
+  const pickeatCode = searchParams.get('code') ?? '';
+  usePickeatStateChecker(pickeatCode);
 
   return (
     <S.Container>
       <TitleArea />
       <ErrorBoundary>
         <Suspense>
-          <RestaurantExclude restaurantsPromise={restaurants.get(code)} />
+          <RestaurantExclude
+            restaurantsPromise={restaurants.get(pickeatCode)}
+          />
         </Suspense>
       </ErrorBoundary>
     </S.Container>

--- a/frontend/src/shared/hooks/usePolling.ts
+++ b/frontend/src/shared/hooks/usePolling.ts
@@ -5,6 +5,7 @@ export function usePolling<T>(
   {
     setData,
     interval = 3000,
+    immediate = false,
     enabled = true,
     errorHandler = (error: Error) => {
       console.error('Polling error:', error.message);
@@ -12,6 +13,7 @@ export function usePolling<T>(
   }: {
     setData: (data: T) => void;
     interval?: number;
+    immediate?: boolean;
     enabled?: boolean;
     errorHandler?: (error: Error) => void;
   }
@@ -38,6 +40,8 @@ export function usePolling<T>(
     };
 
     const intervalId = setInterval(run, interval);
+
+    if (immediate) run();
 
     return () => {
       isUnmounted.current = true;

--- a/frontend/src/shared/hooks/usePolling.ts
+++ b/frontend/src/shared/hooks/usePolling.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react';
 export function usePolling<T>(
   fetcher: () => Promise<T>,
   {
-    setData,
+    onData,
     interval = 3000,
     immediate = false,
     enabled = true,
@@ -11,7 +11,7 @@ export function usePolling<T>(
       console.error('Polling error:', error.message);
     },
   }: {
-    setData: (data: T) => void;
+    onData: (data: T) => void;
     interval?: number;
     immediate?: boolean;
     enabled?: boolean;
@@ -28,7 +28,7 @@ export function usePolling<T>(
     const run = async () => {
       try {
         const result = await fetcher();
-        if (!isUnmounted.current) setData(result);
+        if (!isUnmounted.current) onData(result);
       } catch (err) {
         if (isUnmounted.current) return;
         if (err instanceof Error) {
@@ -47,5 +47,5 @@ export function usePolling<T>(
       isUnmounted.current = true;
       clearInterval(intervalId);
     };
-  }, [fetcher, interval, enabled, setData, errorHandler]);
+  }, [fetcher, interval, enabled, onData, errorHandler]);
 }

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -13,6 +13,8 @@ const __dirname = path.dirname(__filename);
 const env = dotenv.config({ path: path.resolve(__dirname, './.env') }).parsed;
 const MODE = process.env.NODE_ENV || 'development';
 const BASE_URL = MODE === 'production' ? env.BASE_URL_PROD : env.BASE_URL_DEV;
+const API_BASE_URL =
+  MODE === 'production' ? env.API_BASE_URL_PROD : env.API_BASE_URL_DEV;
 
 const envKeys = Object.entries(env).reduce(
   (acc, [key, value]) => {
@@ -22,6 +24,7 @@ const envKeys = Object.entries(env).reduce(
   {
     'process.env.BASE_URL': JSON.stringify(BASE_URL),
     'process.env.NODE_ENV': JSON.stringify(MODE),
+    'process.env.API_BASE_URL': JSON.stringify(API_BASE_URL),
   }
 );
 


### PR DESCRIPTION
## Issue Number
#191

## As-Is
결과 종료 기능을 완성하였습니다.
종료의 동시성, 픽잇 상태 조회, 종료 트리거 등의 기능과 API,  리다이렉트 등을 구현합니다.


## To-Be
- [x]  폴링으로 픽잇 진행 중 픽잇 상태(종료/찾을 수 없음/진행 중)를 조회합니다.
- [x]  픽잇 상태에 따라 isActive = false 시 바로 결과 match-result/pickcode 로 리다이렉트됩니다.
- [x]  결과가 나온 픽잇의 기존 투표 페이지(소거, 선호) URL 에 다시 직접 접근 시 바로 결과로 리다이렉트합니다.
- [x]  투표 종료 여부를 한 번 더 묻는 Confirm 모달이 제작되었습니다.
- [x]  투표 종료 시 ‘결과,동점이 있었는지 여부’ 를 판단해 동률로 인한 랜덤 추첨인지 안내도 추가하였습니다.
- [x]  (Additional) 개발/운영 서버 BASE API 를 분리하였습니다. 


## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
