### PR TITLE
[Feature] 라우트 가드 적용

### DIFF
--- a/frontend/src/domains/login/context/AuthProvider.tsx
+++ b/frontend/src/domains/login/context/AuthProvider.tsx
@@ -10,6 +10,7 @@ import { ACCESS_TOKEN_STORAGE_NAME, accessToken } from '../utils/authStorage';
 
 interface AuthContextType {
   loggedIn: boolean;
+  loading: boolean;
   loginUser: (token: string) => Promise<void>;
   logoutUser: () => void;
 }
@@ -22,6 +23,7 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const [loggedIn, setLoggedIn] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const checkAuth = async () => {
@@ -29,10 +31,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (token) {
         accessToken.save(token);
         setLoggedIn(true);
+        setLoading(false);
         return;
       }
       accessToken.remove();
       setLoggedIn(false);
+      setLoading(false);
     };
     checkAuth();
   }, []);
@@ -60,6 +64,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const value = {
     loggedIn,
+    loading,
     loginUser,
     logoutUser,
   };


### PR DESCRIPTION
## Issue Number
#216 

## As-Is
로그인/비로그인 시의 페이지 라우팅 가드를 구현 및 적용합니다.
이제
 - 로그인하지 않은 상태에서 마이페이지, 방, 방만들기에 접근 시 로그인 페이지로 리다이렉트됩니다.
 - 로그인한 상태에서 로그인, 프로필 생성, 로그인리다이렉트 페이지 접근 시 메인 페이지로 돌아갑니다.

## To-Be
- [x] useAuth 에 loading 상태 추가
- [x] 페이지 라우트 가드 구현 및 적용


## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
