### PR TITLE
[Feat] 회원 닉네임 기본 설정

### DIFF
--- a/frontend/src/domains/pickeat/components/PickeatInfo.tsx
+++ b/frontend/src/domains/pickeat/components/PickeatInfo.tsx
@@ -20,10 +20,9 @@ import { useJoinPickeat } from '../hooks/useJoinPickeat';
 type Props = {
   pickeatData: Promise<PickeatType>;
   defaultNickname: string;
-  nicknameError: string;
 };
 
-function PickeatInfo({ pickeatData, defaultNickname, nicknameError }: Props) {
+function PickeatInfo({ pickeatData, defaultNickname }: Props) {
   const pickeatDetail = use(pickeatData);
   const pickeatLink = `${process.env.BASE_URL}pickeat-detail?code=${pickeatDetail.code}`;
 
@@ -51,8 +50,6 @@ function PickeatInfo({ pickeatData, defaultNickname, nicknameError }: Props) {
       value: 1,
     });
   };
-
-  if (nicknameError) alert(nicknameError);
 
   return (
     <S.Wrapper onSubmit={submitJoinPickeatForm}>

--- a/frontend/src/pages/PickeatDetail.tsx
+++ b/frontend/src/pages/PickeatDetail.tsx
@@ -15,8 +15,6 @@ import { useSearchParams } from 'react-router';
 
 function PickeatDetail() {
   const [defaultNickname, setDefaultNickname] = useState(makeNickname);
-  const [nicknameError, setNicknameError] = useState('');
-
   const [searchParams] = useSearchParams();
   const pickeatCode = searchParams.get('code') ?? '';
   const { loggedIn } = useAuth();
@@ -31,10 +29,8 @@ function PickeatDetail() {
           setDefaultNickname(user.nickname);
         }
       } catch (e) {
-        console.error(e);
-        setNicknameError(
-          '닉네임을 불러오지 못해 랜덤 닉네임이 생성되었습니다.'
-        );
+        alert('닉네임을 불러오지 못해 랜덤 닉네임이 생성되었습니다.');
+        console.log(e);
       }
     };
 
@@ -48,7 +44,6 @@ function PickeatDetail() {
           <PickeatInfo
             pickeatData={pickeat.get(pickeatCode)}
             defaultNickname={defaultNickname}
-            nicknameError={nicknameError}
           />
         </Suspense>
       </ErrorBoundary>


### PR DESCRIPTION
## Issue Number
#248 

## As-Is
<!-- 문제 상황 정의 -->


## To-Be
회원이 픽잇 참여 시 닉네임 기본 입력 기능을 추가했습니다.
<img width="347" height="756" alt="image" src="https://github.com/user-attachments/assets/7e0a7df7-0ead-4988-89dd-1b29d0f21f44" />
회원 정보 요청에 실패 시에도 랜덤으로 닉네임을 생성하여 참여 가능하도록 했습니다. 요청에 실패할 경우 픽잇 참여 중 발생한 에러메시지와는 별개의 위치에 에러 메시지가 표시됩니다.
<img width="350" height="757" alt="image" src="https://github.com/user-attachments/assets/d681c98f-9c1c-43eb-a08c-ed410318f8a4" />

## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
