### PR TITLE
[Refactor] 위시 등록에 카카오 url 추가

### DIFF
--- a/frontend/src/apis/wish.ts
+++ b/frontend/src/apis/wish.ts
@@ -12,7 +12,7 @@ export type WishFormData = {
   roadAddressName: string;
   category: string;
   tags: string[];
-  placeUrl: string;
+  placeUrl?: string;
 };
 
 export const wish = {

--- a/frontend/src/apis/wish.ts
+++ b/frontend/src/apis/wish.ts
@@ -12,6 +12,7 @@ export type WishFormData = {
   roadAddressName: string;
   category: string;
   tags: string[];
+  placeUrl: string;
 };
 
 export const wish = {

--- a/frontend/src/apis/wishlist.ts
+++ b/frontend/src/apis/wishlist.ts
@@ -23,6 +23,7 @@ export type WishesResponse = {
   roadAddressName: string;
   tags: string[];
   wishlistId: number;
+  placeUrl?: string;
 };
 
 export type Wishes = {
@@ -33,6 +34,7 @@ export type Wishes = {
   roadAddressName: string;
   tags: string[];
   wishlistId: number;
+  placeUrl?: string;
 };
 
 export type WishlistType = {
@@ -60,6 +62,7 @@ const convertResponseToWishes = (data: WishesResponse[]) => {
     roadAddressName: d.roadAddressName,
     tags: d.tags,
     wishlistId: d.wishlistId,
+    placeUrl: d.placeUrl,
   }));
 };
 

--- a/frontend/src/domains/pickeat/utils/convertAddress.ts
+++ b/frontend/src/domains/pickeat/utils/convertAddress.ts
@@ -98,7 +98,7 @@ export const getFormDataByAddress = async (address: string) => {
     return {
       name: data.documents[0].place_name,
       roadAddressName: data.documents[0].road_address_name,
-      url: data.documents[0].place_url,
+      placeUrl: data.documents[0].place_url,
     };
   } else {
     return null;

--- a/frontend/src/domains/room/components/Wishlist/WishlistTab.tsx
+++ b/frontend/src/domains/room/components/Wishlist/WishlistTab.tsx
@@ -35,7 +35,15 @@ function WishlistTab({ wishlist, onTabChange, onRefetch }: Props) {
       />
       {wishlist.length > 0 ? (
         wishlist.map(
-          ({ id, name, pictures, category, roadAddressName, tags }) => (
+          ({
+            id,
+            name,
+            pictures,
+            category,
+            roadAddressName,
+            tags,
+            placeUrl,
+          }) => (
             <S.Container key={id}>
               <S.Image
                 src={
@@ -65,6 +73,15 @@ function WishlistTab({ wishlist, onTabChange, onRefetch }: Props) {
                 </S.TopArea>
                 <S.Name>{name}</S.Name>
                 <S.Address>{roadAddressName}</S.Address>
+                {placeUrl && (
+                  <S.LinkButton
+                    href={`${placeUrl}#menuInfo`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    메뉴 보러가기
+                  </S.LinkButton>
+                )}
               </S.Info>
             </S.Container>
           )
@@ -122,7 +139,18 @@ const S = {
   Address: styled.p`
     font: ${({ theme }) => theme.FONTS.body.small};
   `,
+  LinkButton: styled.a`
+    align-items: center;
+    gap: ${({ theme }) => theme.GAP.level2};
 
+    color: ${({ theme }) => theme.PALETTE.gray[50]};
+    font: ${({ theme }) => theme.FONTS.body.xsmall};
+
+    &:hover {
+      color: ${({ theme }) => theme.PALETTE.gray[70]};
+      text-decoration: underline;
+    }
+  `,
   Description: styled.p`
     font: ${({ theme }) => theme.FONTS.body.medium_bold};
     text-align: center;

--- a/frontend/src/domains/room/components/Wishlist/index.tsx
+++ b/frontend/src/domains/room/components/Wishlist/index.tsx
@@ -96,5 +96,6 @@ const S = {
     flex-direction: column;
     gap: ${({ theme }) => theme.GAP.level4};
     overflow-y: scroll;
+    scrollbar-width: none;
   `,
 };

--- a/frontend/src/domains/wishlist/components/WishForm/index.tsx
+++ b/frontend/src/domains/wishlist/components/WishForm/index.tsx
@@ -46,6 +46,12 @@ function WishForm({ formData, onFormChange, onSubmit, errorMessage }: Props) {
           value={formData.roadAddressName}
           onChange={e => onFormChange('roadAddressName', e.target.value)}
         />
+        <Input
+          label="링크 *"
+          name="placeUrl"
+          value={formData.placeUrl}
+          onChange={e => onFormChange('placeUrl', e.target.value)}
+        />
         <S.Label htmlFor="thumbnail">찜 썸네일</S.Label>
         <input
           id="thumbnail"
@@ -80,7 +86,7 @@ const S = {
     display: flex;
     flex-direction: column;
     gap: ${({ theme }) => theme.GAP.level3};
-    overflow: scroll;
+    overflow-y: scroll;
   `,
 
   Label: styled.label`

--- a/frontend/src/domains/wishlist/components/WishForm/index.tsx
+++ b/frontend/src/domains/wishlist/components/WishForm/index.tsx
@@ -47,7 +47,7 @@ function WishForm({ formData, onFormChange, onSubmit, errorMessage }: Props) {
           onChange={e => onFormChange('roadAddressName', e.target.value)}
         />
         <Input
-          label="링크 *"
+          label="링크"
           name="placeUrl"
           value={formData.placeUrl}
           onChange={e => onFormChange('placeUrl', e.target.value)}

--- a/frontend/src/domains/wishlist/hooks/useCreateWish.ts
+++ b/frontend/src/domains/wishlist/hooks/useCreateWish.ts
@@ -41,6 +41,7 @@ export const useCreateWish = (onCreate?: () => void) => {
         category: formData.category as string,
         roadAddressName: formData.roadAddressName as string,
         tags: formData.tags as string[],
+        placeUrl: formData.placeUrl as string,
       });
 
       let imageUploadError = false;


### PR DESCRIPTION
## Issue Number
#258 


## To-Be
<!-- 변경 사항 -->
1. 위시 등록시 카카오 URL 입력
<img width="430" height="411" alt="image" src="https://github.com/user-attachments/assets/9fb044c0-dfcc-45fc-b0b9-f121a95c7e99" />
기본적인 입력은 카카오 API에서 받아온 링크입니다!

2. 위시 목록에서 카카오 URL 보기
<img width="424" height="155" alt="image" src="https://github.com/user-attachments/assets/1ded66d1-a832-412b-8d68-50d6ce98189a" />
카카오 URL이 있을 경우에만 "메뉴보러가기"가 뜨게 구현했습니다.


## Check List
- [X] 빌드, 테스트가 전부 통과되었나요?
- [X] merge할 branch를 확인했나요?
- [X] Assignee를 지정했나요?
- [X] Label을 지정했나요?


## (Optional) Additional Description
