### PR TITLE
[Cicd] 운영환경 cicd 수동실행 기능추가

### DIFF
--- a/.github/workflows/prod-cicd.yml
+++ b/.github/workflows/prod-cicd.yml
@@ -3,6 +3,7 @@ name: Build and Deploy
 on:
   push:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   ci:


### PR DESCRIPTION
## Issue Number
#287

## As-Is
<!-- 문제 상황 정의 -->
운영 애플리케이션을 private ec2로 옮기면서 self-hosted-runner를 새롭게 설정했습니다!
새롭게 설정한 runner를 통해 운영환경 CICD 워크플로우를 실행하여 운영 환경을 세팅함과 동시에
CICD 워크플로우 과정이 제대로 이루어지는 점검하고자 합니다!
이때 운영환경 CICD 워크플로우를 실행하기 위해서는 main에 커밋을 올려야 하는데 간단한 세팅 및 테스트 용도로
main브런치에 더미 커밋을 올리는 것은 바람직하지 않다고 판단됩니다!

(이전 운영환경 CICD는 30일이 지나서 워크플로우 재실행이 불가능했습니다!)

## To-Be
<!-- 변경 사항 -->
그래서 운영환경 CICD에 한해서 수동실행 기능을 추가하는 것을 건의드리고 싶습니다!
수동 실행 기능을 추가하면 이후에 운영환경을 변경하더라도 self-hosted-runner만 세팅하면
보다 쉽게 운영환경을 세팅하고 CICD 워크플로우를 점검할 수 있다고 판단됩니다!


## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
Closed #287 