### PR TITLE
[Refactor] 로깅 타임스탬프 수정 및 logback 설정에서 JSON 출력 포맷 추가

### DIFF
--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 
 on:
-  push:
+  pull_request:
     branches: [ "back/dev" ]
 
 jobs:

--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy
 
 on:
-  pull_request:
+  push:
     branches: [ "back/dev" ]
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+AGENTS.md

--- a/backend/src/main/java/com/pickeat/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/pickeat/backend/global/exception/GlobalExceptionHandler.java
@@ -166,30 +166,11 @@ public class GlobalExceptionHandler {
     }
 
     private void logSafe(Log logObject, LogLevel level) {
-        Map<String, Object> logPayload = logObject.toMap();
-        String summary = resolveSummary(logPayload);
-
         switch (level) {
-            case INFO -> log.info(Markers.appendEntries(logPayload), summary);
-            case WARN -> log.warn(Markers.appendEntries(logPayload), summary);
-            case ERROR -> log.error(Markers.appendEntries(logPayload), summary);
+            case INFO -> log.info(Markers.appendEntries(logObject.fields()), logObject.summary());
+            case WARN -> log.warn(Markers.appendEntries(logObject.fields()), logObject.summary());
+            case ERROR -> log.error(Markers.appendEntries(logObject.fields()), logObject.summary());
         }
-    }
-
-    private String resolveSummary(Map<String, Object> payload) {
-        Object message = payload.get("message");
-        if (message instanceof String msg && !msg.isBlank()) {
-            return msg;
-        }
-        Object customCode = payload.get("customCode");
-        if (customCode instanceof String code && !code.isBlank()) {
-            return code;
-        }
-        Object logType = payload.get("logType");
-        if (logType instanceof String type && !type.isBlank()) {
-            return type;
-        }
-        return "error emitted";
     }
 
     private enum LogLevel {INFO, WARN, ERROR}

--- a/backend/src/main/java/com/pickeat/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/pickeat/backend/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.pickeat.backend.global.exception;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickeat.backend.global.log.dto.ErrorLog;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,7 +24,6 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
-    private final ObjectMapper objectMapper;
 
     @ExceptionHandler(BusinessException.class)
     public ProblemDetail handleBusinessException(BusinessException e) {
@@ -167,19 +164,11 @@ public class GlobalExceptionHandler {
     }
 
     private void logSafe(Object logObject, LogLevel level) {
-        String json;
-        try {
-            json = objectMapper.writeValueAsString(logObject);
-        } catch (JsonProcessingException e) {
-            // 직렬화 실패 시 무조건 error 레벨로 로그
-            log.error("{\"logType\":\"LOG_SERIALIZE_FAIL\",\"message\":\"{}\"}", e.getMessage());
-            return;
-        }
 
         switch (level) {
-            case INFO -> log.info(json);
-            case WARN -> log.warn(json);
-            case ERROR -> log.error(json);
+            case INFO -> log.info("{}", logObject);
+            case WARN -> log.warn("{}", logObject);
+            case ERROR -> log.error("{}", logObject);
         }
     }
 

--- a/backend/src/main/java/com/pickeat/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/pickeat/backend/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.pickeat.backend.global.exception;
 
 import com.pickeat.backend.global.log.dto.ErrorLog;
+import com.pickeat.backend.global.log.dto.Log;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -163,12 +164,12 @@ public class GlobalExceptionHandler {
         logSafe(ErrorLog.createClientErrorLog(status.value(), e, customCode), LogLevel.WARN);
     }
 
-    private void logSafe(Object logObject, LogLevel level) {
+    private void logSafe(Log logObject, LogLevel level) {
 
         switch (level) {
-            case INFO -> log.info("{}", logObject);
-            case WARN -> log.warn("{}", logObject);
-            case ERROR -> log.error("{}", logObject);
+            case INFO -> log.info("{}", logObject.toMap());
+            case WARN -> log.warn("{}", logObject.toMap());
+            case ERROR -> log.error("{}", logObject.toMap());
         }
     }
 

--- a/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
@@ -18,11 +18,10 @@ public class BusinessLogAspect {
 
         String action = businessLogging.value();
         Long userId = extractUserId(joinPoint.getArgs());
-        String message = String.format("User [%s] executed [%s]", userId, action);
 
         Object result = joinPoint.proceed();
-        BusinessLog businessLog = BusinessLog.of(userId, action, message);
-        log.info(Markers.appendEntries(businessLog.toMap()), message);
+        BusinessLog businessLog = BusinessLog.of(userId, action);
+        log.info(Markers.appendEntries(businessLog.fields()), businessLog.summary());
         return result;
     }
 

--- a/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
@@ -1,6 +1,5 @@
 package com.pickeat.backend.global.log;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickeat.backend.global.log.dto.BusinessLog;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -13,8 +12,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class BusinessLogAspect {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     @Around("@annotation(businessLogging)")
     public Object logBusinessAction(ProceedingJoinPoint joinPoint, BusinessLogging businessLogging) throws Throwable {
 
@@ -23,7 +20,7 @@ public class BusinessLogAspect {
         String message = String.format("User [%s] executed [%s]", userId, action);
 
         Object result = joinPoint.proceed();
-        log.info(objectMapper.writeValueAsString(BusinessLog.of(userId, action, message)));
+        log.info("{}", BusinessLog.of(userId, action, message));
         return result;
     }
 

--- a/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
@@ -1,6 +1,5 @@
 package com.pickeat.backend.global.log;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickeat.backend.global.log.dto.BusinessLog;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -12,7 +11,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class BusinessLogAspect {
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Around("@annotation(businessLogging)")
     public Object logBusinessAction(ProceedingJoinPoint joinPoint, BusinessLogging businessLogging) throws Throwable {
@@ -22,7 +20,7 @@ public class BusinessLogAspect {
         String message = String.format("User [%s] executed [%s]", userId, action);
 
         Object result = joinPoint.proceed();
-        log.info(objectMapper.writeValueAsString(BusinessLog.of(userId, action, message)));
+        log.info("{}", BusinessLog.of(userId, action, message));
         return result;
     }
 

--- a/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
@@ -20,7 +20,7 @@ public class BusinessLogAspect {
         String message = String.format("User [%s] executed [%s]", userId, action);
 
         Object result = joinPoint.proceed();
-        log.info("{}", BusinessLog.of(userId, action, message));
+        log.info("{}", BusinessLog.of(userId, action, message).toMap());
         return result;
     }
 

--- a/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
@@ -2,6 +2,7 @@ package com.pickeat.backend.global.log;
 
 import com.pickeat.backend.global.log.dto.BusinessLog;
 import lombok.extern.slf4j.Slf4j;
+import net.logstash.logback.marker.Markers;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -20,7 +21,8 @@ public class BusinessLogAspect {
         String message = String.format("User [%s] executed [%s]", userId, action);
 
         Object result = joinPoint.proceed();
-        log.info("{}", BusinessLog.of(userId, action, message).toMap());
+        BusinessLog businessLog = BusinessLog.of(userId, action, message);
+        log.info(Markers.appendEntries(businessLog.toMap()), message);
         return result;
     }
 

--- a/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/BusinessLogAspect.java
@@ -1,5 +1,6 @@
 package com.pickeat.backend.global.log;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickeat.backend.global.log.dto.BusinessLog;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class BusinessLogAspect {
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Around("@annotation(businessLogging)")
     public Object logBusinessAction(ProceedingJoinPoint joinPoint, BusinessLogging businessLogging) throws Throwable {
@@ -20,7 +22,7 @@ public class BusinessLogAspect {
         String message = String.format("User [%s] executed [%s]", userId, action);
 
         Object result = joinPoint.proceed();
-        log.info("{}", BusinessLog.of(userId, action, message));
+        log.info(objectMapper.writeValueAsString(BusinessLog.of(userId, action, message)));
         return result;
     }
 

--- a/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
@@ -1,5 +1,6 @@
 package com.pickeat.backend.global.log;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickeat.backend.global.log.dto.RequestLog;
 import com.pickeat.backend.global.log.dto.ResponseLog;
 import jakarta.servlet.FilterChain;
@@ -29,6 +30,7 @@ public class LogFilter extends OncePerRequestFilter {
             "/v3/api-docs/**"
     );
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     protected void doFilterInternal(
@@ -52,13 +54,13 @@ public class LogFilter extends OncePerRequestFilter {
 
         try {
             filterChain.doFilter(cacheRequest, cacheResponse);
-            log.info("{}", RequestLog.of(cacheRequest).toMap());
+            log.info("{}", objectMapper.writeValueAsString(RequestLog.of(cacheRequest).toMap()));
 
             //TODO: ContentCachingRequestWrapper는 요청 바디가 실제로 읽힌 후에만 캐시에 저장됨.
             // 따라서 현재 요청 로그를 doFilter 이후에 찍게되면서 로그 순서상 리졸버 단의 예외 로그가 먼저 발생(2025-08-19, 화, 1:45):
 
         } finally {
-            log.info("{}", ResponseLog.of(cacheResponse).toMap());
+            log.info("{}", objectMapper.writeValueAsString(ResponseLog.of(cacheResponse).toMap()));
 
             cacheResponse.copyBodyToResponse();
             MDC.clear();

--- a/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
@@ -1,5 +1,6 @@
 package com.pickeat.backend.global.log;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickeat.backend.global.log.dto.RequestLog;
 import com.pickeat.backend.global.log.dto.ResponseLog;
 import jakarta.servlet.FilterChain;
@@ -29,6 +30,7 @@ public class LogFilter extends OncePerRequestFilter {
             "/v3/api-docs/**"
     );
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     protected void doFilterInternal(
@@ -52,13 +54,13 @@ public class LogFilter extends OncePerRequestFilter {
 
         try {
             filterChain.doFilter(cacheRequest, cacheResponse);
-            log.info("{}", RequestLog.of(cacheRequest));
+            log.info(objectMapper.writeValueAsString(RequestLog.of(cacheRequest)));
 
             //TODO: ContentCachingRequestWrapper는 요청 바디가 실제로 읽힌 후에만 캐시에 저장됨.
             // 따라서 현재 요청 로그를 doFilter 이후에 찍게되면서 로그 순서상 리졸버 단의 예외 로그가 먼저 발생(2025-08-19, 화, 1:45):
 
         } finally {
-            log.info("{}", ResponseLog.of(cacheResponse));
+            log.info(objectMapper.writeValueAsString(ResponseLog.of(cacheResponse)));
 
             cacheResponse.copyBodyToResponse();
             MDC.clear();

--- a/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
@@ -1,6 +1,5 @@
 package com.pickeat.backend.global.log;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickeat.backend.global.log.dto.RequestLog;
 import com.pickeat.backend.global.log.dto.ResponseLog;
 import jakarta.servlet.FilterChain;
@@ -30,7 +29,6 @@ public class LogFilter extends OncePerRequestFilter {
             "/v3/api-docs/**"
     );
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     protected void doFilterInternal(
@@ -54,13 +52,13 @@ public class LogFilter extends OncePerRequestFilter {
 
         try {
             filterChain.doFilter(cacheRequest, cacheResponse);
-            log.info(objectMapper.writeValueAsString(RequestLog.of(cacheRequest)));
+            log.info("{}", RequestLog.of(cacheRequest));
 
             //TODO: ContentCachingRequestWrapper는 요청 바디가 실제로 읽힌 후에만 캐시에 저장됨.
             // 따라서 현재 요청 로그를 doFilter 이후에 찍게되면서 로그 순서상 리졸버 단의 예외 로그가 먼저 발생(2025-08-19, 화, 1:45):
 
         } finally {
-            log.info(objectMapper.writeValueAsString(ResponseLog.of(cacheResponse)));
+            log.info("{}", ResponseLog.of(cacheResponse));
 
             cacheResponse.copyBodyToResponse();
             MDC.clear();

--- a/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
@@ -1,6 +1,5 @@
 package com.pickeat.backend.global.log;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickeat.backend.global.log.dto.RequestLog;
 import com.pickeat.backend.global.log.dto.ResponseLog;
 import jakarta.servlet.FilterChain;
@@ -29,7 +28,6 @@ public class LogFilter extends OncePerRequestFilter {
             "/swagger-ui/**",
             "/v3/api-docs/**"
     );
-    private final ObjectMapper objectMapper;
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
     @Override
@@ -54,13 +52,13 @@ public class LogFilter extends OncePerRequestFilter {
 
         try {
             filterChain.doFilter(cacheRequest, cacheResponse);
-            log.info(objectMapper.writeValueAsString(RequestLog.of(cacheRequest)));
+            log.info("{}", RequestLog.of(cacheRequest));
 
             //TODO: ContentCachingRequestWrapper는 요청 바디가 실제로 읽힌 후에만 캐시에 저장됨.
             // 따라서 현재 요청 로그를 doFilter 이후에 찍게되면서 로그 순서상 리졸버 단의 예외 로그가 먼저 발생(2025-08-19, 화, 1:45):
 
         } finally {
-            log.info(objectMapper.writeValueAsString(ResponseLog.of(cacheResponse)));
+            log.info("{}", ResponseLog.of(cacheResponse));
 
             cacheResponse.copyBodyToResponse();
             MDC.clear();

--- a/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
@@ -1,6 +1,5 @@
 package com.pickeat.backend.global.log;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickeat.backend.global.log.dto.RequestLog;
 import com.pickeat.backend.global.log.dto.ResponseLog;
 import jakarta.servlet.FilterChain;
@@ -12,6 +11,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.logstash.logback.marker.Markers;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
@@ -30,7 +30,6 @@ public class LogFilter extends OncePerRequestFilter {
             "/v3/api-docs/**"
     );
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     protected void doFilterInternal(
@@ -54,13 +53,26 @@ public class LogFilter extends OncePerRequestFilter {
 
         try {
             filterChain.doFilter(cacheRequest, cacheResponse);
-            log.info("{}", objectMapper.writeValueAsString(RequestLog.of(cacheRequest).toMap()));
+
+            var requestLog = RequestLog.of(cacheRequest).toMap();
+            log.info(
+                    Markers.appendEntries(requestLog),
+                    "{} {} handled",
+                    cacheRequest.getMethod(),
+                    requestURI
+            );
 
             //TODO: ContentCachingRequestWrapper는 요청 바디가 실제로 읽힌 후에만 캐시에 저장됨.
             // 따라서 현재 요청 로그를 doFilter 이후에 찍게되면서 로그 순서상 리졸버 단의 예외 로그가 먼저 발생(2025-08-19, 화, 1:45):
 
         } finally {
-            log.info("{}", objectMapper.writeValueAsString(ResponseLog.of(cacheResponse).toMap()));
+            var responseLog = ResponseLog.of(cacheResponse).toMap();
+            log.info(
+                    Markers.appendEntries(responseLog),
+                    "{} responded with status {}",
+                    requestURI,
+                    cacheResponse.getStatus()
+            );
 
             cacheResponse.copyBodyToResponse();
             MDC.clear();

--- a/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
@@ -52,13 +52,13 @@ public class LogFilter extends OncePerRequestFilter {
 
         try {
             filterChain.doFilter(cacheRequest, cacheResponse);
-            log.info("{}", RequestLog.of(cacheRequest));
+            log.info("{}", RequestLog.of(cacheRequest).toMap());
 
             //TODO: ContentCachingRequestWrapper는 요청 바디가 실제로 읽힌 후에만 캐시에 저장됨.
             // 따라서 현재 요청 로그를 doFilter 이후에 찍게되면서 로그 순서상 리졸버 단의 예외 로그가 먼저 발생(2025-08-19, 화, 1:45):
 
         } finally {
-            log.info("{}", ResponseLog.of(cacheResponse));
+            log.info("{}", ResponseLog.of(cacheResponse).toMap());
 
             cacheResponse.copyBodyToResponse();
             MDC.clear();

--- a/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
@@ -54,24 +54,20 @@ public class LogFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(cacheRequest, cacheResponse);
 
-            var requestLog = RequestLog.of(cacheRequest).toMap();
+            RequestLog requestLog = RequestLog.of(cacheRequest, requestURI);
             log.info(
-                    Markers.appendEntries(requestLog),
-                    "{} {} handled",
-                    cacheRequest.getMethod(),
-                    requestURI
+                    Markers.appendEntries(requestLog.fields()),
+                    requestLog.summary()
             );
 
             //TODO: ContentCachingRequestWrapper는 요청 바디가 실제로 읽힌 후에만 캐시에 저장됨.
             // 따라서 현재 요청 로그를 doFilter 이후에 찍게되면서 로그 순서상 리졸버 단의 예외 로그가 먼저 발생(2025-08-19, 화, 1:45):
 
         } finally {
-            var responseLog = ResponseLog.of(cacheResponse).toMap();
+            ResponseLog responseLog = ResponseLog.of(cacheResponse, requestURI);
             log.info(
-                    Markers.appendEntries(responseLog),
-                    "{} responded with status {}",
-                    requestURI,
-                    cacheResponse.getStatus()
+                    Markers.appendEntries(responseLog.fields()),
+                    responseLog.summary()
             );
 
             cacheResponse.copyBodyToResponse();

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/BusinessLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/BusinessLog.java
@@ -1,10 +1,7 @@
 package com.pickeat.backend.global.log.dto;
 
-import org.slf4j.MDC;
-
 public record BusinessLog(
         LogType logType,
-        String requestId,
         Long userId,
         String action,
         String message
@@ -12,7 +9,6 @@ public record BusinessLog(
     public static BusinessLog of(Long userId, String action, String message) {
         return new BusinessLog(
                 LogType.BUSINESS,
-                MDC.get("request_id"),
                 userId,
                 action,
                 message

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/BusinessLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/BusinessLog.java
@@ -1,25 +1,17 @@
 package com.pickeat.backend.global.log.dto;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import org.slf4j.MDC;
 
 public record BusinessLog(
         LogType logType,
-        String timestamp,
         String requestId,
         Long userId,
         String action,
         String message
 ) {
-    private static final String NOW_TIME = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
-            .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-
     public static BusinessLog of(Long userId, String action, String message) {
         return new BusinessLog(
                 LogType.BUSINESS,
-                NOW_TIME,
                 MDC.get("request_id"),
                 userId,
                 action,

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/BusinessLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/BusinessLog.java
@@ -2,26 +2,31 @@ package com.pickeat.backend.global.log.dto;
 
 import java.util.Map;
 
-public record BusinessLog(LogType logType,
-                          Long userId,
-                          String action,
-                          String message) implements Log {
+public record BusinessLog(
+        LogType logType,
+        Long userId,
+        String action
+) implements Log {
 
-    public static BusinessLog of(Long userId, String action, String message) {
+    public static BusinessLog of(Long userId, String action) {
         return new BusinessLog(
                 LogType.BUSINESS,
                 userId,
-                action,
-                message
+                action
         );
     }
 
-    public Map<String, Object> toMap() {
+    @Override
+    public Map<String, Object> fields() {
         return Map.of(
                 "logType", logType.name(),
                 "userId", userId,
-                "action", action,
-                "message", message
+                "action", action
         );
+    }
+
+    @Override
+    public String summary() {
+        return String.format("[%s] User %d executed %s", LogType.BUSINESS.name(), userId, action);
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/BusinessLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/BusinessLog.java
@@ -1,17 +1,27 @@
 package com.pickeat.backend.global.log.dto;
 
-public record BusinessLog(
-        LogType logType,
-        Long userId,
-        String action,
-        String message
-) {
+import java.util.Map;
+
+public record BusinessLog(LogType logType,
+                          Long userId,
+                          String action,
+                          String message) implements Log {
+
     public static BusinessLog of(Long userId, String action, String message) {
         return new BusinessLog(
                 LogType.BUSINESS,
                 userId,
                 action,
                 message
+        );
+    }
+
+    public Map<String, Object> toMap() {
+        return Map.of(
+                "logType", logType.name(),
+                "userId", userId,
+                "action", action,
+                "message", message
         );
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/BusinessLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/BusinessLog.java
@@ -27,6 +27,6 @@ public record BusinessLog(
 
     @Override
     public String summary() {
-        return String.format("[%s] User %d executed %s", LogType.BUSINESS.name(), userId, action);
+        return String.format("[%s] User %d executed %s", logType.name(), userId, action);
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/ErrorLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/ErrorLog.java
@@ -3,12 +3,15 @@ package com.pickeat.backend.global.log.dto;
 import java.util.HashMap;
 import java.util.Map;
 
-public record ErrorLog(LogType logType,
-                       int status,
-                       String message,
-                       String type,
-                       String customCode,
-                       String stackTrace) implements Log {
+public record ErrorLog(
+        LogType logType,
+        int status,
+        String message,
+        String type,
+        String customCode,
+        String stackTrace
+) implements Log {
+
     public static ErrorLog createServerErrorLog(
             int status,
             Throwable ex,
@@ -64,7 +67,8 @@ public record ErrorLog(LogType logType,
         return sb.toString();
     }
 
-    public Map<String, Object> toMap() {
+    @Override
+    public Map<String, Object> fields() {
         Map<String, Object> map = new HashMap<>();
         map.put("logType", logType.name());
         map.put("status", status);
@@ -73,5 +77,13 @@ public record ErrorLog(LogType logType,
         map.put("customCode", customCode);
         map.put("stackTrace", stackTrace);
         return map;
+    }
+
+    @Override
+    public String summary() {
+        if (customCode != null && !customCode.isBlank()) {
+            return String.format("[%s] %d %s occurred", logType.name(), status, customCode);
+        }
+        return String.format("%s occurred", logType.name());
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/ErrorLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/ErrorLog.java
@@ -1,13 +1,14 @@
 package com.pickeat.backend.global.log.dto;
 
-public record ErrorLog(
-        LogType logType,
-        int status,
-        String message,
-        String type,
-        String customCode,
-        String stackTrace
-) {
+import java.util.HashMap;
+import java.util.Map;
+
+public record ErrorLog(LogType logType,
+                       int status,
+                       String message,
+                       String type,
+                       String customCode,
+                       String stackTrace) implements Log {
     public static ErrorLog createServerErrorLog(
             int status,
             Throwable ex,
@@ -61,5 +62,16 @@ public record ErrorLog(
             sb.append(stackTrace[i]).append("\n");
         }
         return sb.toString();
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("logType", logType.name());
+        map.put("status", status);
+        map.put("message", message);
+        map.put("type", type);
+        map.put("customCode", customCode);
+        map.put("stackTrace", stackTrace);
+        return map;
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/ErrorLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/ErrorLog.java
@@ -1,10 +1,7 @@
 package com.pickeat.backend.global.log.dto;
 
-import org.slf4j.MDC;
-
 public record ErrorLog(
         LogType logType,
-        String requestId,
         int status,
         String message,
         String type,
@@ -18,7 +15,6 @@ public record ErrorLog(
     ) {
         return new ErrorLog(
                 LogType.SERVER_ERROR,
-                MDC.get("request_id"),
                 status,
                 ex.getMessage(),
                 ex.getClass().getName(),
@@ -34,7 +30,6 @@ public record ErrorLog(
     ) {
         return new ErrorLog(
                 LogType.EXTERNAL_ERROR,
-                MDC.get("request_id"),
                 status,
                 ex.getMessage(),
                 ex.getClass().getName(),
@@ -50,7 +45,6 @@ public record ErrorLog(
     ) {
         return new ErrorLog(
                 LogType.CLIENT_ERROR,
-                MDC.get("request_id"),
                 status,
                 ex.getMessage(),
                 ex.getClass().getName(),

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/ErrorLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/ErrorLog.java
@@ -1,13 +1,9 @@
 package com.pickeat.backend.global.log.dto;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import org.slf4j.MDC;
 
 public record ErrorLog(
         LogType logType,
-        String timestamp,
         String requestId,
         int status,
         String message,
@@ -15,9 +11,6 @@ public record ErrorLog(
         String customCode,
         String stackTrace
 ) {
-    private static final String NOW_TIME = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
-            .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-
     public static ErrorLog createServerErrorLog(
             int status,
             Throwable ex,
@@ -25,7 +18,6 @@ public record ErrorLog(
     ) {
         return new ErrorLog(
                 LogType.SERVER_ERROR,
-                NOW_TIME,
                 MDC.get("request_id"),
                 status,
                 ex.getMessage(),
@@ -42,7 +34,6 @@ public record ErrorLog(
     ) {
         return new ErrorLog(
                 LogType.EXTERNAL_ERROR,
-                NOW_TIME,
                 MDC.get("request_id"),
                 status,
                 ex.getMessage(),
@@ -59,7 +50,6 @@ public record ErrorLog(
     ) {
         return new ErrorLog(
                 LogType.CLIENT_ERROR,
-                NOW_TIME,
                 MDC.get("request_id"),
                 status,
                 ex.getMessage(),

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/Log.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/Log.java
@@ -1,0 +1,7 @@
+package com.pickeat.backend.global.log.dto;
+
+import java.util.Map;
+
+public interface Log {
+    Map<String, Object> toMap();
+}

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/Log.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/Log.java
@@ -3,5 +3,7 @@ package com.pickeat.backend.global.log.dto;
 import java.util.Map;
 
 public interface Log {
-    Map<String, Object> toMap();
+    Map<String, Object> fields();
+
+    String summary();
 }

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/RequestLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/RequestLog.java
@@ -9,7 +9,6 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
 
 public record RequestLog(
         LogType logType,
-        String timestamp,
         String requestId,
         String requestUri,
         String clientIp,
@@ -23,7 +22,6 @@ public record RequestLog(
 
         return new RequestLog(
                 LogType.REQUEST,
-                NOW_TIME,
                 MDC.get("request_id"),
                 request.getRequestURI(),
                 request.getRemoteAddr(),

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/RequestLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/RequestLog.java
@@ -1,14 +1,10 @@
 package com.pickeat.backend.global.log.dto;
 
 import java.nio.charset.StandardCharsets;
-import org.slf4j.MDC;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
 public record RequestLog(
         LogType logType,
-        String requestId,
-        String requestUri,
-        String clientIp,
         String method,
         String body
 ) {
@@ -16,9 +12,6 @@ public record RequestLog(
 
         return new RequestLog(
                 LogType.REQUEST,
-                MDC.get("request_id"),
-                request.getRequestURI(),
-                request.getRemoteAddr(),
                 request.getMethod(),
                 new String(request.getContentAsByteArray(), StandardCharsets.UTF_8)
         );

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/RequestLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/RequestLog.java
@@ -1,9 +1,6 @@
 package com.pickeat.backend.global.log.dto;
 
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import org.slf4j.MDC;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
@@ -15,9 +12,6 @@ public record RequestLog(
         String method,
         String body
 ) {
-    private static final String NOW_TIME = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
-            .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-
     public static RequestLog of(ContentCachingRequestWrapper request) {
 
         return new RequestLog(

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/RequestLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/RequestLog.java
@@ -1,27 +1,38 @@
 package com.pickeat.backend.global.log.dto;
 
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
-public record RequestLog(LogType logType,
-                         String method,
-                         String body) implements Log {
-    public static RequestLog of(ContentCachingRequestWrapper request) {
+public record RequestLog(
+        LogType logType,
+        String method,
+        String uri,
+        String body
+) implements Log {
 
+    public static RequestLog of(ContentCachingRequestWrapper request, String requestURI) {
+        String body = new String(request.getContentAsByteArray(), StandardCharsets.UTF_8);
         return new RequestLog(
                 LogType.REQUEST,
                 request.getMethod(),
-                new String(request.getContentAsByteArray(), StandardCharsets.UTF_8)
+                requestURI,
+                body
         );
     }
 
-    public Map<String, Object> toMap() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("logType", logType.name());
-        map.put("method", method);
-        map.put("body", body);
-        return map;
+    @Override
+    public Map<String, Object> fields() {
+        return Map.of(
+                "logType", logType.name(),
+                "method", method,
+                "uri", uri,
+                "body", body
+        );
+    }
+
+    @Override
+    public String summary() {
+        return String.format("[%s] %s %s", logType.name(), method, uri);
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/RequestLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/RequestLog.java
@@ -1,13 +1,13 @@
 package com.pickeat.backend.global.log.dto;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
-public record RequestLog(
-        LogType logType,
-        String method,
-        String body
-) {
+public record RequestLog(LogType logType,
+                         String method,
+                         String body) implements Log {
     public static RequestLog of(ContentCachingRequestWrapper request) {
 
         return new RequestLog(
@@ -15,5 +15,13 @@ public record RequestLog(
                 request.getMethod(),
                 new String(request.getContentAsByteArray(), StandardCharsets.UTF_8)
         );
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("logType", logType.name());
+        map.put("method", method);
+        map.put("body", body);
+        return map;
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
@@ -1,9 +1,6 @@
 package com.pickeat.backend.global.log.dto;
 
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import org.slf4j.MDC;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
@@ -12,9 +9,6 @@ public record ResponseLog(
         String requestId,
         String body
 ) {
-    private static final String NOW_TIME = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
-            .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-
     public static ResponseLog of(ContentCachingResponseWrapper response) {
         String responseBody = "";
         try {

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
@@ -9,7 +9,6 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 
 public record ResponseLog(
         LogType logType,
-        String timestamp,
         String requestId,
         String body
 ) {
@@ -26,7 +25,6 @@ public record ResponseLog(
 
         return new ResponseLog(
                 LogType.RESPONSE,
-                NOW_TIME,
                 MDC.get("request_id"),
                 responseBody
         );

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
@@ -1,12 +1,12 @@
 package com.pickeat.backend.global.log.dto;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
-public record ResponseLog(
-        LogType logType,
-        String body
-) {
+public record ResponseLog(LogType logType,
+                          String body) implements Log {
     public static ResponseLog of(ContentCachingResponseWrapper response) {
         String responseBody = "";
         try {
@@ -19,5 +19,12 @@ public record ResponseLog(
                 LogType.RESPONSE,
                 responseBody
         );
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("logType", logType.name());
+        map.put("body", body);
+        return map;
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
@@ -1,12 +1,10 @@
 package com.pickeat.backend.global.log.dto;
 
 import java.nio.charset.StandardCharsets;
-import org.slf4j.MDC;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 public record ResponseLog(
         LogType logType,
-        String requestId,
         String body
 ) {
     public static ResponseLog of(ContentCachingResponseWrapper response) {
@@ -19,7 +17,6 @@ public record ResponseLog(
 
         return new ResponseLog(
                 LogType.RESPONSE,
-                MDC.get("request_id"),
                 responseBody
         );
     }

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
@@ -1,30 +1,43 @@
 package com.pickeat.backend.global.log.dto;
 
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
-public record ResponseLog(LogType logType,
-                          String body) implements Log {
-    public static ResponseLog of(ContentCachingResponseWrapper response) {
-        String responseBody = "";
+public record ResponseLog(
+        LogType logType,
+        String uri,
+        int status,
+        String body
+) implements Log {
+
+    public static ResponseLog of(ContentCachingResponseWrapper response, String requestURI) {
+        String responseBody;
         try {
             responseBody = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
         } catch (Exception e) {
             responseBody = "Error reading response body";
         }
-
         return new ResponseLog(
                 LogType.RESPONSE,
+                requestURI,
+                response.getStatus(),
                 responseBody
         );
     }
 
-    public Map<String, Object> toMap() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("logType", logType.name());
-        map.put("body", body);
-        return map;
+    @Override
+    public Map<String, Object> fields() {
+        return Map.of(
+                "logType", logType.name(),
+                "uri", uri,
+                "status", status,
+                "body", body
+        );
+    }
+
+    @Override
+    public String summary() {
+        return String.format("[%s] %s %d", logType.name(), uri, status);
     }
 }

--- a/backend/src/main/resources/logback-dev.xml
+++ b/backend/src/main/resources/logback-dev.xml
@@ -8,9 +8,25 @@
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
-
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <timeZone>Asia/Seoul</timeZone>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <fieldName>@timestamp</fieldName>
+                    <timeZone>Asia/Seoul</timeZone>
+                </timestamp>
+                <pattern>
+                    <pattern>
+                        {
+                        "severity": "%level",
+                        "logger": "%logger",
+                        "thread": "%thread",
+                        "message": "%message"
+                        }
+                    </pattern>
+                </pattern>
+                <mdc/>
+                <arguments/>
+            </providers>
         </encoder>
     </appender>
 

--- a/backend/src/main/resources/logback-dev.xml
+++ b/backend/src/main/resources/logback-dev.xml
@@ -26,6 +26,9 @@
                 <logstashMarkers/>
                 <arguments/>
                 <mdc/>
+                <message>
+                    <fieldName>summary</fieldName>
+                </message>
             </providers>
         </encoder>
     </appender>

--- a/backend/src/main/resources/logback-dev.xml
+++ b/backend/src/main/resources/logback-dev.xml
@@ -14,14 +14,20 @@
                     <fieldName>@timestamp</fieldName>
                     <timeZone>Asia/Seoul</timeZone>
                 </timestamp>
-                <level/>
-                <loggerName/>
-                <threadName/>
+                <pattern>
+                    <pattern>
+                        {
+                        "severity": "%level",
+                        "logger": "%logger",
+                        "thread": "%thread",
+                        "message": "%message"
+                        }
+                    </pattern>
+                </pattern>
                 <mdc/>
                 <arguments/>
             </providers>
         </encoder>
-
     </appender>
 
     <root level="INFO">

--- a/backend/src/main/resources/logback-dev.xml
+++ b/backend/src/main/resources/logback-dev.xml
@@ -14,16 +14,17 @@
                     <fieldName>@timestamp</fieldName>
                     <timeZone>Asia/Seoul</timeZone>
                 </timestamp>
-                <pattern>
-                    <pattern>
-                        {
-                        "severity": "%level",
-                        "logger": "%logger",
-                        "thread": "%thread",
-                        "message": "%message"
-                        }
-                    </pattern>
-                </pattern>
+                <level>
+                    <fieldName>severity</fieldName>
+                </level>
+                <loggerName>
+                    <fieldName>logger</fieldName>
+                </loggerName>
+                <threadName>
+                    <fieldName>thread</fieldName>
+                </threadName>
+                <logstashMarkers/>
+                <arguments/>
                 <mdc/>
             </providers>
         </encoder>

--- a/backend/src/main/resources/logback-dev.xml
+++ b/backend/src/main/resources/logback-dev.xml
@@ -8,7 +8,20 @@
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <fieldName>@timestamp</fieldName>
+                    <timeZone>Asia/Seoul</timeZone>
+                </timestamp>
+                <level/>
+                <loggerName/>
+                <threadName/>
+                <mdc/>
+                <arguments/>
+            </providers>
+        </encoder>
+
     </appender>
 
     <root level="INFO">

--- a/backend/src/main/resources/logback-dev.xml
+++ b/backend/src/main/resources/logback-dev.xml
@@ -8,25 +8,9 @@
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
-        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-            <providers>
-                <timestamp>
-                    <fieldName>@timestamp</fieldName>
-                    <timeZone>Asia/Seoul</timeZone>
-                </timestamp>
-                <pattern>
-                    <pattern>
-                        {
-                        "severity": "%level",
-                        "logger": "%logger",
-                        "thread": "%thread",
-                        "message": "%message"
-                        }
-                    </pattern>
-                </pattern>
-                <mdc/>
-                <arguments/>
-            </providers>
+
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <timeZone>Asia/Seoul</timeZone>
         </encoder>
     </appender>
 

--- a/backend/src/main/resources/logback-dev.xml
+++ b/backend/src/main/resources/logback-dev.xml
@@ -19,12 +19,12 @@
                         {
                         "severity": "%level",
                         "logger": "%logger",
-                        "thread": "%thread"
+                        "thread": "%thread",
+                        "message": "%message"
                         }
                     </pattern>
                 </pattern>
                 <mdc/>
-                <arguments/>
             </providers>
         </encoder>
     </appender>

--- a/backend/src/main/resources/logback-dev.xml
+++ b/backend/src/main/resources/logback-dev.xml
@@ -19,8 +19,7 @@
                         {
                         "severity": "%level",
                         "logger": "%logger",
-                        "thread": "%thread",
-                        "message": "%message"
+                        "thread": "%thread"
                         }
                     </pattern>
                 </pattern>

--- a/backend/src/main/resources/logback-prod.xml
+++ b/backend/src/main/resources/logback-prod.xml
@@ -8,7 +8,29 @@
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <fieldName>@timestamp</fieldName>
+                    <timeZone>Asia/Seoul</timeZone>
+                </timestamp>
+                <level>
+                    <fieldName>severity</fieldName>
+                </level>
+                <loggerName>
+                    <fieldName>logger</fieldName>
+                </loggerName>
+                <threadName>
+                    <fieldName>thread</fieldName>
+                </threadName>
+                <logstashMarkers/>
+                <arguments/>
+                <mdc/>
+                <message>
+                    <fieldName>summary</fieldName>
+                </message>
+            </providers>
+        </encoder>
     </appender>
 
     <root level="INFO">


### PR DESCRIPTION
#296 

## As-Is (문제 상황)
### 잘못된 타임스탬프 기록
- 각 로그 DTO(BusinessLog, RequestLog, ResponseLog, ErrorLog)가 static final 타임스탬프를 사용해, 실제 요청 시각이 아니라 애플리케이션 기동 시점의 시간이 계속 기록됨.

### JSON이 아닌 문자열 로그
- DTO를 objectMapper.writeValueAsString()으로 직렬화한 뒤 log.info에 넘겼기 때문에, 로그의 message 필드에 JSON이 아니라 "{"logType":"..."}" 형태의 문자열로 저장됨.

### 중복된 필드
- 각 DTO가 requestId, clientIp, requestUri 등 MDC에 이미 들어가 있는 값도 별도 필드로 중복 보관. 로그에는 동일한 값이 message 안과 MDC 영역에 두 번 찍힘.

### 분석/시각화 어려움
- Grafana에서 message 안 JSON을 파싱할 수 없어 logType, method, body, status 같은 중요한 필드를 기준으로 필터링/집계하기 힘들었음.

### Logback 설정 제약
- 기존 설정은 %message만 찍는 형태라, Structured Logging을 지원하지 못했음.

## To-Be (개선 사항)

### 타임스탬프 개선
- 각 로그 생성 시점의 시간이 기록되도록 static final 제거.

### 구조화된 로깅 적용
- log.info("{}", object) 대신 StructuredArguments/Markers.appendEntries(...)를 사용해 DTO 내부 필드가 JSON으로 직렬화되도록 변경.

### 중복 제거
- DTO에서 requestId, clientIp, requestUri 등 MDC에 이미 포함된 필드들을 제거하고, Logback 설정에서 <mdc/> provider를 통해 별도 JSON 필드로 출력되도록 함. → 결과적으로 로그가 더 간결해지고 중복 제거.

### Logback 설정 확장
- LoggingEventCompositeJsonEncoder에 <message/>, <arguments/>, <mdc/> provider를 추가.
- 사람이 읽을 수 있는 로그 요약(summary)은 message 필드에
- DTO 필드들은 arguments를 통해 JSON 최상위 필드로
- MDC 값은 별도 필드로 출력

### 시각화 용이성 확보
- 이제 Grafana에서 logType, method, body, status 등 필드를 기반으로 필터링, 집계, 대시보드화가 가능해짐.

## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
