### PR TITLE
[Fix] kkubulim subset 생성 오류 수정

### DIFF
--- a/frontend/src/domains/pickeat/restaurantExclude/components/restaurantTabList/restaurantList/RestaurantList.tsx
+++ b/frontend/src/domains/pickeat/restaurantExclude/components/restaurantTabList/restaurantList/RestaurantList.tsx
@@ -13,10 +13,10 @@ function RestaurantList({ restaurantList }: Props) {
   return (
     <>
       {restaurantList.length === 0 ? (
-        <S.NoContentTitle>
+        <S.NoContentPointText>
           해당 카테고리에
           <br /> 식당이 없어요ㅠㅠ
-        </S.NoContentTitle>
+        </S.NoContentPointText>
       ) : (
         <S.Container>
           {restaurantList.map(restaurant =>
@@ -43,7 +43,7 @@ const S = {
 
     padding: ${({ theme }) => theme.PADDING.p5};
   `,
-  NoContentTitle: styled.p`
+  NoContentPointText: styled.p`
     width: 100%;
     height: 240px;
     display: flex;

--- a/frontend/src/domains/room/components/RoomDetailTab/index.tsx
+++ b/frontend/src/domains/room/components/RoomDetailTab/index.tsx
@@ -80,10 +80,6 @@ const S = {
     padding: ${({ theme }) => theme.PADDING.p7};
   `,
 
-  Name: styled.span`
-    font: ${({ theme }) => theme.FONTS.heading.large_style};
-  `,
-
   ButtonWrapper: styled.div`
     width: 100%;
     display: flex;

--- a/frontend/src/domains/room/components/WishlistTab/WishlistTab.tsx
+++ b/frontend/src/domains/room/components/WishlistTab/WishlistTab.tsx
@@ -42,7 +42,9 @@ function WishlistTab() {
             />
           ))
         ) : (
-          <S.EmptyDescription>찜을 추가해보세요!</S.EmptyDescription>
+          <S.EmptyDescriptionPointText>
+            찜을 추가해보세요!
+          </S.EmptyDescriptionPointText>
         )}
       </S.Wishlist>
 
@@ -81,7 +83,7 @@ const S = {
     overflow: scroll;
     scrollbar-width: none;
   `,
-  EmptyDescription: styled.span`
+  EmptyDescriptionPointText: styled.span`
     width: 100%;
 
     margin-top: 20px;

--- a/frontend/src/pages/CreateRoom.tsx
+++ b/frontend/src/pages/CreateRoom.tsx
@@ -22,7 +22,7 @@ function CreateRoom() {
 
   return (
     <S.Container>
-      <S.Title>방 만들기</S.Title>
+      <S.TitlePointText>방 만들기</S.TitlePointText>
       <S.Description>
         함께 식사할 멤버를 초대하여 방을 만들어봐요.
       </S.Description>
@@ -63,7 +63,7 @@ const S = {
     padding: 0 ${({ theme }) => theme.PADDING.p7};
   `,
 
-  Title: styled.span`
+  TitlePointText: styled.span`
     font: ${({ theme }) => theme.FONTS.heading.large_style};
   `,
 

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -27,7 +27,7 @@ function Login() {
     <S.Container>
       <S.Title>
         <S.TitleWrapper>
-          로그인하고 <S.Point>더 빠르게</S.Point>
+          로그인하고 <S.PointText>더 빠르게</S.PointText>
         </S.TitleWrapper>
         식당을 정해보아요
       </S.Title>
@@ -52,7 +52,7 @@ const S = {
     color: ${({ theme }) => theme.PALETTE.gray[60]};
     font: ${({ theme }) => theme.FONTS.heading.large};
   `,
-  Point: styled.h1`
+  PointText: styled.h1`
     color: ${({ theme }) => theme.PALETTE.primary[50]};
     font: ${({ theme }) => theme.FONTS.heading.large_style};
   `,

--- a/frontend/src/pages/pickeat/preferRestaurant/components/Title.tsx
+++ b/frontend/src/pages/pickeat/preferRestaurant/components/Title.tsx
@@ -13,7 +13,7 @@ function Title() {
       <S.Description>
         <S.Line>
           <S.WriteBox>
-            <S.WriteText>가고 싶은 식당</S.WriteText>
+            <S.PointText>가고 싶은 식당</S.PointText>
           </S.WriteBox>
           <S.TitleText>에</S.TitleText>
         </S.Line>
@@ -69,7 +69,7 @@ const S = {
     align-items: center;
     border-bottom: 2px solid ${({ theme }) => theme.PALETTE.gray[50]};
   `,
-  WriteText: styled.p`
+  PointText: styled.p`
     color: ${({ theme }) => theme.PALETTE.secondary[95]};
     font: ${({ theme }) => theme.FONTS.heading.small_style};
   `,

--- a/frontend/src/pages/pickeat/restaurantExclude/components/Title.tsx
+++ b/frontend/src/pages/pickeat/restaurantExclude/components/Title.tsx
@@ -14,7 +14,7 @@ function Title() {
       </S.TitleBox>
       <S.Description>
         <S.Line>
-          <S.WriteText>안 땡기는 식당</S.WriteText>
+          <S.PointText>안 땡기는 식당</S.PointText>
           <S.TitleText>을</S.TitleText>
         </S.Line>
         <S.Line>
@@ -63,7 +63,7 @@ const S = {
     align-items: center;
     gap: ${({ theme }) => theme.GAP.level2};
   `,
-  WriteText: styled.p`
+  PointText: styled.p`
     height: 36px;
 
     padding: 0 ${({ theme }) => theme.PADDING.px3};

--- a/frontend/src/shared/components/share/SharePanel.tsx
+++ b/frontend/src/shared/components/share/SharePanel.tsx
@@ -12,7 +12,7 @@ function SharePanel({ url, description }: Props) {
   return (
     <S.Container>
       <S.TitleArea>
-        <S.Title>공유하기</S.Title>
+        <S.TitlePointText>공유하기</S.TitlePointText>
         <S.Description>{description}</S.Description>
       </S.TitleArea>
       <QRCode url={url} />
@@ -36,7 +36,7 @@ const S = {
   TitleArea: styled.div`
     text-align: center;
   `,
-  Title: styled.h1`
+  TitlePointText: styled.h1`
     font: ${({ theme }) => theme.FONTS.heading.large_style};
   `,
   Description: styled.span`

--- a/frontend/src/shared/styles/global.ts
+++ b/frontend/src/shared/styles/global.ts
@@ -17,7 +17,7 @@ const FONTS = {
     medium_style: `700 28px/150% ${fontFamilyStyle}`,
     small: `600 19px/150% ${fontFamily}`,
     small_style: `600 22px/150% ${fontFamilyStyle}`,
-    small_style_static: `600 22px/150% BM Kkubulim Static`,
+    small_style_static: `600 22px/150% ${fontFamilyStyle}`,
   },
   body: {
     large: `400 19px/150% ${fontFamily}`,

--- a/frontend/tools/kkubulim/buildSubset.js
+++ b/frontend/tools/kkubulim/buildSubset.js
@@ -58,7 +58,7 @@ async function collectText() {
   let allText = texts.join(' ').normalize('NFC');
 
   allText = removeEmojis(allText);
-  allText = allText.replace(/\s+/g, '');
+  allText = allText.replace(/&nbsp;/g, '');
 
   // Set으로 중복 문자 제거 → 배열로 변환 → 다시 문자열로
   //  - subset-font에서 중복을 제거해주긴 하지만 콘솔에 결과를 확인해 보고 싶어서!


### PR DESCRIPTION
## Issue Number
#299 

안녕하세요 카멜 머핀😎
아배고프다

몇몇 페이지에서 오류 방지로 설정해뒀던 fallback(kkubulim dynamic subset)폰트를 요청하고 있어 확인해 보니 kkubulim static subset에 공백을 포함하지 않고 있었습니당😱 공백도 글리프였다니,, 일반 스페이스(U+0020)와 nbsp(U+00A0)가 포함되지 않아 각각 118,119번 kkubulim dynamic subset을 요청하고 있더라구요! 공백을 포함하도록 변경했구 ca5bfa92ec0ab655afa8ca1643497dc3b2d22399 만 확인해 주시면 될 것 같슴다

추가로 '& nbsp;' 6글자 포함 여부에 대해서는 같이 논의해 봐도 좋을 것 같아요!
<img width="640" height="35" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/3acb21d2-d12c-436d-bbd7-183149e4379f" />
<img width="635" height="21" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/5b51c8d2-c93c-4d5f-8cf2-49e6e9840712" />
용량은 1.2kb 정도 차이가 나더라구요! 조건문을 추가할지 아예 포함시켜버릴지 고민이 됩니당
build 속도나 용량 차이 둘 다 체감될 정도는 아니라서 일단은 포함되지 않게 구현해놨구 의견 있으시면 코멘트 달아주세용


## To-Be
- [x] 꾸불림체 적용 중인 정적 텍스트의 styled-component 이름에 'PointText' 추가
- [x] kkubulim static subset 공백 포함하도록 변경
- [x] kkubulim static subset &nbsp; 포함하지 않도록 변경


## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
