### PR TITLE
[Refactor] 프로그레스 버튼 리디자인

### DIFF
--- a/frontend/src/domains/pickeat/matchResult/components/PickeatEndButton.tsx
+++ b/frontend/src/domains/pickeat/matchResult/components/PickeatEndButton.tsx
@@ -66,6 +66,7 @@ function PickeatEndButton() {
 
 export default PickeatEndButton;
 
+//TODO: 지우기
 function AnimatedResultButton({
   children,
   totalParticipants,

--- a/frontend/src/shared/components/actions/ProgressButton.stories.tsx
+++ b/frontend/src/shared/components/actions/ProgressButton.stories.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+import ProgressButton from './ProgressButton';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof ProgressButton> = {
+  component: ProgressButton,
+  title: 'ProgressButton',
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProgressButton>;
+
+export const Default: Story = {
+  render: () => {
+    const [completed, setCompleted] = useState(1);
+    return (
+      <div
+        style={{
+          height: '100px',
+          padding: '1rem',
+          background: '#f9f9f9',
+        }}
+      >
+        <ProgressButton
+          text="프로그레스 버튼 클릭해 보세용"
+          total={5}
+          current={completed}
+          onClick={() => setCompleted(prev => (prev !== 5 ? prev + 1 : 0))}
+        />
+      </div>
+    );
+  },
+};

--- a/frontend/src/shared/components/actions/ProgressButton.tsx
+++ b/frontend/src/shared/components/actions/ProgressButton.tsx
@@ -19,7 +19,7 @@ function ProgressButton({ text, total, current, ...props }: Props) {
 }
 
 const S = {
-  //TODO: 색 theme에서 뽑아쓰기
+  //TODO: 색, 폰트 theme에서 뽑아쓰기
   Container: styled.button<{ progress: number }>`
     width: 90%;
     height: 52px;

--- a/frontend/src/shared/components/actions/ProgressButton.tsx
+++ b/frontend/src/shared/components/actions/ProgressButton.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+import { ComponentProps } from 'react';
+
+type Props = {
+  text: string;
+  total: number;
+  current: number;
+} & ComponentProps<'button'>;
+
+function ProgressButton({ text, total, current, ...props }: Props) {
+  const progress = total ? current / total : 0;
+
+  return (
+    <S.ButtonContainer progress={progress} {...props}>
+      {text}
+    </S.ButtonContainer>
+  );
+}
+
+const S = {
+  //TODO: 색 theme에서 뽑아쓰기
+  ButtonContainer: styled.button<{ progress: number }>`
+    width: 90%;
+    height: 52px;
+
+    position: fixed;
+    bottom: calc(
+      env(safe-area-inset-bottom) + ${({ theme }) => theme.PADDING.p6}
+    );
+    left: 50%;
+    z-index: ${({ theme }) => theme.Z_INDEX.fixed};
+
+    background: linear-gradient(to right, #ffda1e 0%, #ffda1e 100%);
+    background-color: ${({ theme }) => theme.PALETTE.gray[10]};
+    background-size: ${({ progress }) => progress * 100}% 100%;
+    background-repeat: no-repeat;
+
+    color: ${({ theme }) => theme.PALETTE.gray[100]};
+    font:
+      600 17px/150% Pretendard,
+      sans-serif;
+
+    transition: background-size 0.3s ease;
+    border-radius: 12px;
+    transform: translateX(-50%);
+  `,
+};
+
+export default ProgressButton;

--- a/frontend/src/shared/components/actions/ProgressButton.tsx
+++ b/frontend/src/shared/components/actions/ProgressButton.tsx
@@ -11,15 +11,15 @@ function ProgressButton({ text, total, current, ...props }: Props) {
   const progress = total ? current / total : 0;
 
   return (
-    <S.ButtonContainer progress={progress} {...props}>
+    <S.Container progress={progress} {...props}>
       {text}
-    </S.ButtonContainer>
+    </S.Container>
   );
 }
 
 const S = {
   //TODO: 색 theme에서 뽑아쓰기
-  ButtonContainer: styled.button<{ progress: number }>`
+  Container: styled.button<{ progress: number }>`
     width: 90%;
     height: 52px;
 

--- a/frontend/src/shared/components/actions/ProgressButton.tsx
+++ b/frontend/src/shared/components/actions/ProgressButton.tsx
@@ -8,7 +8,8 @@ type Props = {
 } & ComponentProps<'button'>;
 
 function ProgressButton({ text, total, current, ...props }: Props) {
-  const progress = total ? current / total : 0;
+  const progress =
+    total > 0 && current > 0 && current <= total ? current / total : 0;
 
   return (
     <S.Container progress={progress} {...props}>


### PR DESCRIPTION
## Issue Number
#341 

## To-Be
https://github.com/user-attachments/assets/9a0d5d81-20a4-4311-a22d-d3a7458e2616

프로그레스 버튼을 재사용 가능한 형태의 컴포넌트로 구현했습니다!
내부 요소의 width => button의 배경 색상을 통해 진척도를 표시하는 방식으로 변경했습니당
이 방식에 문제되는 부분이 있다면 알려주십쇼😃
피그마에 반짝거리는 효과가 없어서 단색으로 지정했는데 혹시 기존의 shimer효과가 필요하다면 말해주데용

## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
