### PR TITLE
[Refactor] 로그 body 제거로 응답 로그 단순화

### DIFF
--- a/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/LogFilter.java
@@ -60,9 +60,6 @@ public class LogFilter extends OncePerRequestFilter {
                     requestLog.summary()
             );
 
-            //TODO: ContentCachingRequestWrapper는 요청 바디가 실제로 읽힌 후에만 캐시에 저장됨.
-            // 따라서 현재 요청 로그를 doFilter 이후에 찍게되면서 로그 순서상 리졸버 단의 예외 로그가 먼저 발생(2025-08-19, 화, 1:45):
-
         } finally {
             ResponseLog responseLog = ResponseLog.of(cacheResponse, requestURI);
             log.info(

--- a/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
+++ b/backend/src/main/java/com/pickeat/backend/global/log/dto/ResponseLog.java
@@ -1,28 +1,19 @@
 package com.pickeat.backend.global.log.dto;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 public record ResponseLog(
         LogType logType,
         String uri,
-        int status,
-        String body
+        int status
 ) implements Log {
 
     public static ResponseLog of(ContentCachingResponseWrapper response, String requestURI) {
-        String responseBody;
-        try {
-            responseBody = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
-        } catch (Exception e) {
-            responseBody = "Error reading response body";
-        }
         return new ResponseLog(
                 LogType.RESPONSE,
                 requestURI,
-                response.getStatus(),
-                responseBody
+                response.getStatus()
         );
     }
 
@@ -31,8 +22,7 @@ public record ResponseLog(
         return Map.of(
                 "logType", logType.name(),
                 "uri", uri,
-                "status", status,
-                "body", body
+                "status", status
         );
     }
 

--- a/backend/src/main/resources/logback-local.xml
+++ b/backend/src/main/resources/logback-local.xml
@@ -2,8 +2,28 @@
     <property name="CONSOLE_LOG_PATTERN"
               value="[%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul}] %green([%thread]) %highlight(%-5level) - %msg%n"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <fieldName>@timestamp</fieldName>
+                    <timeZone>Asia/Seoul</timeZone>
+                </timestamp>
+                <logLevel>
+                    <fieldName>severity</fieldName>
+                </logLevel>
+                <loggerName>
+                    <fieldName>logger</fieldName>
+                </loggerName>
+                <threadName>
+                    <fieldName>thread</fieldName>
+                </threadName>
+                <logstashMarkers/>
+                <arguments/>
+                <mdc/>
+                <message>
+                    <fieldName>summary</fieldName>
+                </message>
+            </providers>
         </encoder>
     </appender>
 


### PR DESCRIPTION
## Issue Number
close #437 


## As-Is

응답 로그에 body 전체가 포함되어 있어 로그 크기가 지나치게 커짐

Loki/Grafana에서 로그 조회 시 불필요한 데이터가 많아 가독성이 떨어짐

## To-Be

응답 로그에서 body 필드를 제외하고, 상태 코드・URI・처리 시간 등 핵심 메타데이터만 남김

로그 크기를 줄이고 수집기(Loki 등)의 저장 비용 및 분석 효율 개선


## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
