### PR TITLE
env: 부하 테스트 환경 구성

### DIFF
--- a/.github/workflows/load-test-ci.yml
+++ b/.github/workflows/load-test-ci.yml
@@ -1,0 +1,55 @@
+name: load-test-ci.yml
+
+on:
+  push:
+    branches: [ "load-test-inmeory" ]
+
+jobs:
+  ci:
+    runs-on: ubuntu-24.04
+    environment: dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SUBMODULE_KEY }}
+          submodules: recursive
+
+      - name: Update Submodule
+        run: git submodule update --remote
+
+      - name: Generate short SHA
+        id: meta
+        run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: gradle
+
+      - name: Build JAR
+        working-directory: ./backend
+        run: ./gradlew clean build -x test --no-daemon --build-cache
+
+      - name: Login Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:load-test
+            ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:${{ steps.meta.outputs.short_sha }}
+          build-args: |
+            SPRING_ACTIVE_PROFILE=stress

--- a/backend/src/main/java/com/pickeat/backend/global/config/DataSourceConfig.java
+++ b/backend/src/main/java/com/pickeat/backend/global/config/DataSourceConfig.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-@Profile({"dev", "prod"})
+@Profile({"dev", "prod", "stress"})
 @Configuration
 @EnableTransactionManagement
 public class DataSourceConfig {

--- a/backend/src/main/java/com/pickeat/backend/global/config/MetricsConfig.java
+++ b/backend/src/main/java/com/pickeat/backend/global/config/MetricsConfig.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Profile;
 
 @Configuration
 @Slf4j
-@Profile("!test")
+@Profile({"local", "dev", "prod", "stress"})
 public class MetricsConfig {
 
     @Bean

--- a/backend/src/main/java/com/pickeat/backend/stress/login/StressLoginConfiguration.java
+++ b/backend/src/main/java/com/pickeat/backend/stress/login/StressLoginConfiguration.java
@@ -1,0 +1,63 @@
+package com.pickeat.backend.stress.login;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pickeat.backend.login.application.LoginClient;
+import com.pickeat.backend.login.application.OidcPublicKeyProvider;
+import com.pickeat.backend.login.infrastructure.KakaoJwksCache;
+import com.pickeat.backend.login.infrastructure.KakaoJwksClient;
+import com.pickeat.backend.login.infrastructure.KakaoJwtRSAProperties;
+import com.pickeat.backend.login.infrastructure.KakaoLoginApiProperties;
+import com.pickeat.backend.login.infrastructure.KakaoLoginClient;
+import com.pickeat.backend.login.infrastructure.KakaoOidcPublicKeyProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Profile({"stress"})
+@Configuration
+@RequiredArgsConstructor
+public class StressLoginConfiguration {
+
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public LoginClient kakaoLoginClient(KakaoLoginApiProperties properties) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.getConnectTimeout());
+        factory.setReadTimeout(properties.getReadTimeout());
+
+        RestClient restClient = RestClient.builder().requestFactory(factory)
+                .baseUrl(properties.getBaseUrl())
+                .defaultHeader("Content-Type", "application/x-www-form-urlencoded;charset=utf-8").build();
+
+        return new KakaoLoginClient(properties.getRestApiKey(), restClient,
+                objectMapper);
+    }
+
+    @Bean
+    public OidcPublicKeyProvider kakaOidcPublicKeyProvider(KakaoJwksClient kakaoJwksClient,
+            KakaoJwksCache kakaoJwksCache) {
+
+        return new KakaoOidcPublicKeyProvider(kakaoJwksClient, kakaoJwksCache);
+    }
+
+    @Bean
+    public KakaoJwksCache kakaoJwksCache() {
+        return new KakaoJwksCache();
+    }
+
+    @Bean
+    public KakaoJwksClient kakaoJwksClient(KakaoJwtRSAProperties properties) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.getConnectTimeout());
+        factory.setReadTimeout(properties.getReadTimeout());
+
+        RestClient restClient = RestClient.builder().requestFactory(factory)
+                .defaultHeader("Content-Type", "application/x-www-form-urlencoded;charset=utf-8").build();
+
+        return new KakaoJwksClient(restClient);
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/stress/restaurant/StressRestaurantSearchClient.java
+++ b/backend/src/main/java/com/pickeat/backend/stress/restaurant/StressRestaurantSearchClient.java
@@ -1,0 +1,28 @@
+package com.pickeat.backend.stress.restaurant;
+
+import com.pickeat.backend.restaurant.application.RestaurantSearchClient;
+import com.pickeat.backend.restaurant.application.dto.request.RestaurantRequest;
+import com.pickeat.backend.restaurant.application.dto.request.RestaurantSearchRequest;
+import com.pickeat.backend.restaurant.domain.FoodCategory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class StressRestaurantSearchClient implements RestaurantSearchClient {
+
+    @Override
+    public List<RestaurantRequest> getRestaurants(RestaurantSearchRequest request) {
+        List<RestaurantRequest> restaurants = new ArrayList<>();
+        for (int i = 0; i < request.size(); i++) {
+            restaurants.add(RestaurantRequest.fromLocation(
+                    request.query() + "음식" + i,
+                    FoodCategory.getCategoryNameBy(request.query()),
+                    ThreadLocalRandom.current().nextInt(0, request.radius() + 1),
+                    "도로명 주소" + i,
+                    "식당 URL" + i,
+                    "태그" + i
+            ));
+        }
+        return restaurants;
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/stress/restaurant/StressRestaurantSearchClientConfiguration.java
+++ b/backend/src/main/java/com/pickeat/backend/stress/restaurant/StressRestaurantSearchClientConfiguration.java
@@ -1,0 +1,18 @@
+package com.pickeat.backend.stress.restaurant;
+
+import com.pickeat.backend.restaurant.application.RestaurantSearchClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile({"stress"})
+@Configuration
+@RequiredArgsConstructor
+public class StressRestaurantSearchClientConfiguration {
+
+    @Bean
+    public RestaurantSearchClient kakaoRestaurantSearchClient() {
+        return new StressRestaurantSearchClient();
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/stress/wish/StressImageUploadClient.java
+++ b/backend/src/main/java/com/pickeat/backend/stress/wish/StressImageUploadClient.java
@@ -1,0 +1,23 @@
+package com.pickeat.backend.stress.wish;
+
+import com.pickeat.backend.wish.application.ImageUploadClient;
+import com.pickeat.backend.wish.application.dto.request.ImageRequest;
+import java.util.UUID;
+import org.springframework.web.multipart.MultipartFile;
+
+public class StressImageUploadClient implements ImageUploadClient {
+
+    private final String defaultImageUrl;
+    private final String keyPrefix;
+
+    public StressImageUploadClient(String defaultImageUrl, String keyPrefix) {
+        this.defaultImageUrl = defaultImageUrl;
+        this.keyPrefix = keyPrefix;
+    }
+
+    @Override
+    public ImageRequest uploadImage(MultipartFile multipartFile) {
+        String key = keyPrefix + UUID.randomUUID();
+        return new ImageRequest(key, defaultImageUrl);
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/stress/wish/StressImageUploadClientConfiguration.java
+++ b/backend/src/main/java/com/pickeat/backend/stress/wish/StressImageUploadClientConfiguration.java
@@ -1,0 +1,20 @@
+package com.pickeat.backend.stress.wish;
+
+import com.pickeat.backend.wish.application.ImageUploadClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile({"stress"})
+@Configuration
+public class StressImageUploadClientConfiguration {
+
+    @Bean
+    public ImageUploadClient localImageUploadClient(
+            @Value("${default.wish.image.url}") String defaultImageUrl,
+            @Value("${external.s3.wish.image.key.prefix}") String keyPrefix
+    ) {
+        return new StressImageUploadClient(defaultImageUrl, keyPrefix);
+    }
+}

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,22 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProfile name="local">
-        <include resource="logback-local.xml"/>
-    </springProfile>
+  <springProfile name="local">
+    <include resource="logback-local.xml"/>
+  </springProfile>
 
-    <springProfile name="test">
-        <include resource="logback-local.xml"/>
-    </springProfile>
+  <springProfile name="test">
+    <include resource="logback-local.xml"/>
+  </springProfile>
 
-    <springProfile name="dev">
-        <include resource="logback-dev.xml"/>
-    </springProfile>
+  <springProfile name="stress">
+    <include resource="logback-local.xml"/>
+  </springProfile>
 
-    <springProfile name="prod">
-        <include resource="logback-prod.xml"/>
-    </springProfile>
+  <springProfile name="dev">
+    <include resource="logback-dev.xml"/>
+  </springProfile>
 
-    <root level="INFO">
-        <appender-ref ref="STDOUT"/>
-    </root>
+  <springProfile name="prod">
+    <include resource="logback-prod.xml"/>
+  </springProfile>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
 </configuration>

--- a/backend/src/main/resources/logback-stress.xml
+++ b/backend/src/main/resources/logback-stress.xml
@@ -1,0 +1,39 @@
+<configuration>
+  <property name="LOGS_ROOT_PATH" value="/var/logs"/>
+
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ROOT_PATH}/app.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_ROOT_PATH}/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>10MB</maxFileSize>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+      <providers>
+        <timestamp>
+          <fieldName>@timestamp</fieldName>
+          <timeZone>Asia/Seoul</timeZone>
+        </timestamp>
+        <logLevel>
+          <fieldName>severity</fieldName>
+        </logLevel>
+        <loggerName>
+          <fieldName>logger</fieldName>
+        </loggerName>
+        <threadName>
+          <fieldName>thread</fieldName>
+        </threadName>
+        <logstashMarkers/>
+        <arguments/>
+        <mdc/>
+        <message>
+          <fieldName>summary</fieldName>
+        </message>
+      </providers>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="FILE"/>
+  </root>
+</configuration>


### PR DESCRIPTION
## Issue Number
#441 


## As-Is
<!-- 문제 상황 정의 -->
현재까지는 프로덕션 코드에 부하 테스트 환경 관련 코드를 포함시키지 않기 위해,
부하 테스트가 필요할 때마다 별도의 브랜치를 생성하고 새로운 부하 환경을 구성해왔습니다.

하지만 이러한 방식은 매번 환경을 새로 세팅해야 하는 비효율적인 작업이 반복된다는 문제가 있습니다.

이에 따라, 부하 테스트 환경 구성 코드를 프로덕션 코드에 포함시키되,
Spring의 Profile 설정을 통해 부하 환경이외에서는 환경에서는 해당 코드가 비활성화될 수 있도록 관리하려고 합니다.

## To-Be
<!-- 변경 사항 -->
- [x] 부하 테스트 환경 CICD 워크플로우 추가
- [x] 부하 테스트 환경 관련 외부 의존성 추가

## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
Closed #441 