### PR TITLE
refactor: 로그인 토큰 만료 시 재로그인 리다이렉트

### DIFF
--- a/frontend/src/apis/pickeat.ts
+++ b/frontend/src/apis/pickeat.ts
@@ -1,3 +1,4 @@
+import { useAuth } from '@domains/login/context/AuthProvider';
 import { joinCode } from '@domains/pickeat/utils/joinStorage';
 import { getLatLngByAddress } from '@domains/pickeat/utils/kakaoLocalAPI';
 
@@ -458,12 +459,24 @@ export const pickeatQuery = {
     });
   },
   useSuspenseGetParticipating: (pickeatCode: string) => {
+    const showToast = useShowToast();
+    const { logoutUser } = useAuth();
+    const navigate = useNavigate();
+
     return useSuspenseQuery({
       queryKey: [BASE_PATH, 'participatingPickeat', pickeatCode],
       queryFn: async () => {
         try {
           return await pickeat.getParticipating();
-        } catch {
+        } catch (e) {
+          if (e instanceof ApiError && e.status === 401) {
+            showToast({
+              mode: 'ERROR',
+              message: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+            });
+            logoutUser();
+            navigate(ROUTE_PATH.LOGIN);
+          }
           return null;
         }
       },

--- a/frontend/src/apis/pickeat.ts
+++ b/frontend/src/apis/pickeat.ts
@@ -459,24 +459,12 @@ export const pickeatQuery = {
     });
   },
   useSuspenseGetParticipating: () => {
-    const showToast = useShowToast();
-    const { logoutUser } = useAuth();
-    const navigate = useNavigate();
-
     return useSuspenseQuery({
       queryKey: [BASE_PATH, 'participatingPickeat'],
       queryFn: async () => {
         try {
           return await pickeat.getParticipating();
-        } catch (e) {
-          if (e instanceof ApiError && e.status === 401) {
-            showToast({
-              mode: 'ERROR',
-              message: '로그인이 만료되었습니다. 다시 로그인해주세요.',
-            });
-            logoutUser();
-            navigate(ROUTE_PATH.LOGIN);
-          }
+        } catch {
           return null;
         }
       },

--- a/frontend/src/apis/pickeat.ts
+++ b/frontend/src/apis/pickeat.ts
@@ -458,13 +458,13 @@ export const pickeatQuery = {
       },
     });
   },
-  useSuspenseGetParticipating: (pickeatCode: string) => {
+  useSuspenseGetParticipating: () => {
     const showToast = useShowToast();
     const { logoutUser } = useAuth();
     const navigate = useNavigate();
 
     return useSuspenseQuery({
-      queryKey: [BASE_PATH, 'participatingPickeat', pickeatCode],
+      queryKey: [BASE_PATH, 'participatingPickeat'],
       queryFn: async () => {
         try {
           return await pickeat.getParticipating();

--- a/frontend/src/apis/pickeat.ts
+++ b/frontend/src/apis/pickeat.ts
@@ -1,4 +1,3 @@
-import { useAuth } from '@domains/login/context/AuthProvider';
 import { joinCode } from '@domains/pickeat/utils/joinStorage';
 import { getLatLngByAddress } from '@domains/pickeat/utils/kakaoLocalAPI';
 

--- a/frontend/src/apis/room.ts
+++ b/frontend/src/apis/room.ts
@@ -1,3 +1,5 @@
+import { useAuth } from '@domains/login/context/AuthProvider';
+
 import { ROUTE_PATH } from '@routes/routePath';
 
 import { useShowToast } from '@provider/ToastProvider';
@@ -7,7 +9,7 @@ import { joinAsPath } from '@utils/createUrl';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 
-import { apiClient, BASE_URL_VERSION } from './apiClient';
+import { apiClient, ApiError, BASE_URL_VERSION } from './apiClient';
 import { Pickeat, PickeatResponse } from './pickeat';
 import { queryClient } from './queryClient';
 import { convertResponseToUsers, User, UserResponse } from './users';
@@ -103,6 +105,7 @@ export const roomQuery = {
   useGet: (roomId: number) => {
     const showToast = useShowToast();
     const navigate = useNavigate();
+    const { logoutUser } = useAuth();
     return useQuery({
       queryKey: ['room', roomId],
       queryFn: async () => {
@@ -110,12 +113,22 @@ export const roomQuery = {
           const response = await room.get(roomId);
           if (!response) throw new Error('방 정보를 불러올 수 없습니다.');
           return response;
-        } catch {
-          showToast({
-            mode: 'ERROR',
-            message: '방 정보를 불러오는데 실패했습니다.',
-          });
-          navigate(ROUTE_PATH.MY_PAGE, { replace: true });
+        } catch (e) {
+          if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
+            showToast({
+              mode: 'WARN',
+              message: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+            });
+            logoutUser();
+            navigate(ROUTE_PATH.LOGIN);
+            return;
+          } else {
+            showToast({
+              mode: 'ERROR',
+              message: '방 정보를 불러오는데 실패했습니다.',
+            });
+            navigate(ROUTE_PATH.MY_PAGE, { replace: true });
+          }
         }
       },
       throwOnError: false,
@@ -123,6 +136,8 @@ export const roomQuery = {
   },
   usePost: (onCreate: () => void) => {
     const showToast = useShowToast();
+    const navigate = useNavigate();
+    const { logoutUser } = useAuth();
 
     return useMutation({
       mutationFn: async ({
@@ -137,35 +152,39 @@ export const roomQuery = {
       },
       onSuccess: async ({ roomId, userIds }) => {
         if (roomId && userIds.length > 0) {
-          try {
-            await room.postMember(roomId, userIds);
-          } catch {
-            showToast({
-              mode: 'WARN',
-              message: '방 생성은 완료 되었지만, 초대 중 문제가 발생했습니다.',
-            });
-            queryClient.invalidateQueries({ queryKey: ['rooms'] });
-            onCreate();
-            return;
-          }
+          await room.postMember(roomId, userIds);
+        } else {
+          showToast({
+            mode: 'WARN',
+            message: '방 생성은 완료 되었지만, 초대 중 문제가 발생했습니다.',
+          });
+          queryClient.invalidateQueries({ queryKey: ['rooms'] });
+          onCreate();
         }
-        queryClient.invalidateQueries({ queryKey: ['rooms'] });
-        showToast({
-          mode: 'SUCCESS',
-          message: '방 생성 완료!',
-        });
-        onCreate();
+        return;
       },
-      onError() {
-        showToast({
-          mode: 'ERROR',
-          message: '방 생성 중 문제가 발생했습니다.',
-        });
+      onError(e) {
+        if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
+          showToast({
+            mode: 'WARN',
+            message: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+          });
+          logoutUser();
+          navigate(ROUTE_PATH.LOGIN);
+          return;
+        } else {
+          showToast({
+            mode: 'ERROR',
+            message: '방 생성 중 문제가 발생했습니다.',
+          });
+        }
       },
     });
   },
   usePostMember: (roomId: number) => {
     const showToast = useShowToast();
+    const navigate = useNavigate();
+    const { logoutUser } = useAuth();
 
     return useMutation({
       mutationFn: ({ userIds }: { userIds: number[] }) =>
@@ -177,7 +196,16 @@ export const roomQuery = {
         });
         queryClient.invalidateQueries({ queryKey: ['includeMembers', roomId] });
       },
-      onError() {
+      onError(e) {
+        if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
+          showToast({
+            mode: 'WARN',
+            message: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+          });
+          logoutUser();
+          navigate(ROUTE_PATH.LOGIN);
+          return;
+        }
         showToast({
           mode: 'ERROR',
           message: '초대에 실패했습니다. 다시 시도해 주세요.',
@@ -200,6 +228,8 @@ export const roomQuery = {
   },
   useExitRoom: ({ onExit }: { onExit: () => void }) => {
     const showToast = useShowToast();
+    const navigate = useNavigate();
+    const { logoutUser } = useAuth();
 
     return useMutation({
       mutationFn: async (roomId: number) => room.exitRoom(roomId),
@@ -212,11 +242,21 @@ export const roomQuery = {
         // rooms api 의 쿼리를 이렇게 상수화 안해도 되는걸까?
         queryClient.invalidateQueries({ queryKey: ['rooms'] });
       },
-      onError() {
-        showToast({
-          mode: 'ERROR',
-          message: '방 나가기 중 문제가 발생했습니다.',
-        });
+      onError(e) {
+        if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
+          showToast({
+            mode: 'WARN',
+            message: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+          });
+          logoutUser();
+          navigate(ROUTE_PATH.LOGIN);
+          return;
+        } else {
+          showToast({
+            mode: 'ERROR',
+            message: '방 나가기 중 문제가 발생했습니다.',
+          });
+        }
       },
     });
   },

--- a/frontend/src/apis/rooms.ts
+++ b/frontend/src/apis/rooms.ts
@@ -46,11 +46,16 @@ export const roomsQuery = {
         } catch (e) {
           if (e instanceof ApiError && e.status === 401) {
             showToast({
-              mode: 'ERROR',
+              mode: 'WARN',
               message: '로그인이 만료되었습니다. 다시 로그인해주세요.',
             });
             logoutUser();
             navigate(ROUTE_PATH.LOGIN);
+          } else {
+            showToast({
+              mode: 'WARN',
+              message: '로그인이 필요합니다.',
+            });
           }
           return [];
         }

--- a/frontend/src/apis/rooms.ts
+++ b/frontend/src/apis/rooms.ts
@@ -1,8 +1,15 @@
+import { useAuth } from '@domains/login/context/AuthProvider';
+
+import { ROUTE_PATH } from '@routes/routePath';
+
+import { useShowToast } from '@provider/ToastProvider';
+
 import { joinAsPath } from '@utils/createUrl';
 
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
 
-import { apiClient, BASE_URL_VERSION } from './apiClient';
+import { apiClient, ApiError, BASE_URL_VERSION } from './apiClient';
 import { Room, RoomResponse } from './room';
 
 const convertResponseToRooms = (data: RoomResponse[]) => {
@@ -27,12 +34,24 @@ export const rooms = {
 
 export const roomsQuery = {
   useSuspenseGet: () => {
+    const showToast = useShowToast();
+    const { logoutUser } = useAuth();
+    const navigate = useNavigate();
+
     return useSuspenseQuery({
       queryKey: [BASE_PATH],
       queryFn: async () => {
         try {
           return await rooms.get();
-        } catch {
+        } catch (e) {
+          if (e instanceof ApiError && e.status === 401) {
+            showToast({
+              mode: 'ERROR',
+              message: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+            });
+            logoutUser();
+            navigate(ROUTE_PATH.LOGIN);
+          }
           return [];
         }
       },

--- a/frontend/src/apis/users.ts
+++ b/frontend/src/apis/users.ts
@@ -1,13 +1,10 @@
 import { useAuth } from '@domains/login/context/AuthProvider';
 
-import { ROUTE_PATH } from '@routes/routePath';
-
 import { useShowToast } from '@provider/ToastProvider';
 
 import { createQueryString, joinAsPath } from '@utils/createUrl';
 
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router';
 
 import { apiClient, ApiError, BASE_URL_VERSION } from './apiClient';
 

--- a/frontend/src/apis/users.ts
+++ b/frontend/src/apis/users.ts
@@ -1,8 +1,15 @@
+import { useAuth } from '@domains/login/context/AuthProvider';
+
+import { ROUTE_PATH } from '@routes/routePath';
+
+import { useShowToast } from '@provider/ToastProvider';
+
 import { createQueryString, joinAsPath } from '@utils/createUrl';
 
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
 
-import { apiClient, BASE_URL_VERSION } from './apiClient';
+import { apiClient, ApiError, BASE_URL_VERSION } from './apiClient';
 
 export type UserResponse = {
   id: number;
@@ -35,13 +42,9 @@ const BASE_PATH = 'users';
 const users = {
   get: async (): Promise<User> => {
     const path = joinAsPath(BASE_URL_VERSION[2], BASE_PATH);
-    try {
-      const response = await apiClient.get<UserResponse>(path);
-      if (response) return convertResponseToUser(response);
-      throw new Error('유저를 찾을 수 없습니다.');
-    } catch {
-      throw new Error('유저를 찾을 수 없습니다.');
-    }
+    const response = await apiClient.get<UserResponse>(path);
+    if (response) return convertResponseToUser(response);
+    return { id: -1, nickname: '' };
   },
   getMembers: async (nickname: string): Promise<User[]> => {
     const url = joinAsPath(BASE_URL_VERSION[2], BASE_PATH, 'search');
@@ -54,12 +57,22 @@ const users = {
 
 export const usersQuery = {
   useSuspenseGet: () => {
+    const showToast = useShowToast();
+    const { logoutUser } = useAuth();
     return useSuspenseQuery({
       queryKey: [BASE_PATH],
       queryFn: async () => {
         try {
           return await users.get();
-        } catch {
+        } catch (e) {
+          if (e instanceof ApiError && e.status === 401) {
+            showToast({
+              mode: 'ERROR',
+              message: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+            });
+            logoutUser();
+          }
+
           // TODO : 현재는 user 정보에 에러 처리를 따로 해주는 곳이 없어
           // 빈 객체로 처리하고 있는데, try catch 역할을 하는 에러바운더리를 만들 때
           // default nickname 을 넣어주는 로직을 에러바운더리로 옮기면 어떨까합니다.

--- a/frontend/src/apis/wish.ts
+++ b/frontend/src/apis/wish.ts
@@ -1,4 +1,7 @@
+import { useAuth } from '@domains/login/context/AuthProvider';
 import { accessToken } from '@domains/login/utils/authStorage';
+
+import { ROUTE_PATH } from '@routes/routePath';
 
 import { useShowToast } from '@provider/ToastProvider';
 
@@ -7,8 +10,9 @@ import { joinAsPath } from '@utils/createUrl';
 import { FoodCategory } from '@constants/foodCategory';
 
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
 
-import { apiClient, BASE_URL_VERSION } from './apiClient';
+import { apiClient, ApiError, BASE_URL_VERSION } from './apiClient';
 import { queryClient } from './queryClient';
 
 type Picture = {
@@ -158,6 +162,8 @@ export const wishQuery = {
   },
   useDelete: (roomId: number) => {
     const showToast = useShowToast();
+    const navigate = useNavigate();
+    const { logoutUser } = useAuth();
 
     return useMutation({
       mutationFn: (wishId: number) => wish.delete(wishId),
@@ -168,11 +174,21 @@ export const wishQuery = {
           message: '삭제 완료!',
         });
       },
-      onError() {
-        showToast({
-          mode: 'ERROR',
-          message: '삭제에 실패했습니다. 다시 시도해 주세요.',
-        });
+      onError(e) {
+        if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
+          showToast({
+            mode: 'WARN',
+            message: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+          });
+          logoutUser();
+          navigate(ROUTE_PATH.LOGIN);
+          return;
+        } else {
+          showToast({
+            mode: 'ERROR',
+            message: '삭제에 실패했습니다. 다시 시도해 주세요.',
+          });
+        }
       },
     });
   },

--- a/frontend/src/domains/profile/components/ParticipantPickeat.tsx
+++ b/frontend/src/domains/profile/components/ParticipantPickeat.tsx
@@ -6,15 +6,13 @@ import { pickeatQuery } from '@apis/pickeat';
 import { generateRouterPath } from '@routes/routePath';
 
 import styled from '@emotion/styled';
-import { useNavigate, useSearchParams } from 'react-router';
+import { useNavigate } from 'react-router';
 
 function ParticipantPickeat() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const pickeatCode = searchParams.get('code') ?? '';
 
   const { data: participatingPickeatData } =
-    pickeatQuery.useSuspenseGetParticipating(pickeatCode);
+    pickeatQuery.useSuspenseGetParticipating();
 
   return (
     <S.Container>

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -25,7 +25,6 @@ type Content = {
 };
 
 function Main() {
-  console.log('픽잇을 사용해주셔서 감사합니다! 😊 좋은 하루되세요!');
   const navigate = useNavigate();
   const showToast = useShowToast();
   const [searchParams] = useSearchParams();


### PR DESCRIPTION
## Issue Number
#414 

## As-Is
토큰 만료(401) 시 로그인 혹은 회원가입을 유도한다.


## To-Be
<!-- 변경 사항 -->
- [x] 토큰 만료 시 재로그인이 필요함을 안내합니다.
    - [x] 유저정보 조회(닉네임 등) 실패 시, 토스트 안내 + 로그아웃 처리
    - [x] 마이페이지에 해당하는 기능 401 실패 시(방 조회, 참여중인 픽잇 등) 토스트 안내 + 로그아웃 처리 + 로그인 페이지 리다이렉트

## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description
