### PR TITLE
[Feat] 카테고리별 식당 조회 추가

### DIFF
--- a/.github/workflows/prod-cicd.yml
+++ b/.github/workflows/prod-cicd.yml
@@ -64,14 +64,14 @@ jobs:
 
       - name: Copy Docker Compose
         run: |
-          sudo cp ./backend/docker/docker-compose.prod.yml /home/ubuntu/application/docker-compose.yml
+          sudo cp ./backend/docker/docker-compose.prod.yml /home/ubuntu/pickeat-prod/application/docker-compose.yml
 
       - name: Run Blue-Green Deploy
         run: |
           if [ -f "/home/ubuntu/deploy.sh" ]; then
             echo "🚀 Running deploy script..."
-            sudo chmod +x /home/ubuntu/deploy.sh
-            sudo /home/ubuntu/deploy.sh
+            sudo chmod +x /home/ubuntu/pickeat-prod/deploy.sh
+            sudo /home/ubuntu/pickeat-prod/deploy.sh
           else
             echo "❌ deploy.sh not found!"
             exit 1

--- a/.github/workflows/prod-cicd.yml
+++ b/.github/workflows/prod-cicd.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run Blue-Green Deploy
         run: |
-          if [ -f "/home/ubuntu/deploy.sh" ]; then
+          if [ -f "/home/ubuntu/pickeat-prod/deploy.sh" ]; then
             echo "🚀 Running deploy script..."
             sudo chmod +x /home/ubuntu/pickeat-prod/deploy.sh
             sudo /home/ubuntu/pickeat-prod/deploy.sh

--- a/backend/src/main/java/com/pickeat/backend/restaurant/application/RestaurantService.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/application/RestaurantService.java
@@ -10,6 +10,7 @@ import com.pickeat.backend.pickeat.domain.repository.PickeatRepository;
 import com.pickeat.backend.restaurant.application.dto.request.RestaurantExcludeRequest;
 import com.pickeat.backend.restaurant.application.dto.request.RestaurantRequest;
 import com.pickeat.backend.restaurant.application.dto.response.RestaurantResponse;
+import com.pickeat.backend.restaurant.domain.FoodCategory;
 import com.pickeat.backend.restaurant.domain.Restaurant;
 import com.pickeat.backend.restaurant.domain.RestaurantLike;
 import com.pickeat.backend.restaurant.domain.repository.RestaurantBulkRepository;
@@ -50,10 +51,17 @@ public class RestaurantService {
         restaurantBulkRepository.batchInsert(restaurants);
     }
 
-    public List<RestaurantResponse> getPickeatRestaurants(String pickeatCode, Boolean isExcluded, Long participantId) {
+    public List<RestaurantResponse> getPickeatRestaurants(String pickeatCode,
+                                                          Boolean isExcluded,
+                                                          FoodCategory foodCategory,
+                                                          Long participantId
+    ) {
         Pickeat pickeat = getPickeatByCode(pickeatCode);
-        List<Restaurant> restaurants = restaurantRepository.findByPickeatIdAndIsExcludedIfProvided(pickeat.getId(),
-                isExcluded);
+        List<Restaurant> restaurants = restaurantRepository.findByPickeatIdAndIsExcludedAndFoodCategoryIfProvided(
+                pickeat.getId(),
+                isExcluded,
+                foodCategory
+        );
         List<RestaurantResponse> response = new ArrayList<>();
 
         for (Restaurant restaurant : restaurants) {

--- a/backend/src/main/java/com/pickeat/backend/restaurant/domain/repository/RestaurantRepository.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/domain/repository/RestaurantRepository.java
@@ -1,5 +1,6 @@
 package com.pickeat.backend.restaurant.domain.repository;
 
+import com.pickeat.backend.restaurant.domain.FoodCategory;
 import com.pickeat.backend.restaurant.domain.Restaurant;
 import java.util.Collection;
 import java.util.List;
@@ -14,11 +15,14 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     @Query("""
             select r from Restaurant r
-            where (r.pickeatId = :pickeatId)
+            where r.pickeatId = :pickeatId
                 and (:isExcluded IS NULL OR r.isExcluded = :isExcluded)
+                and (:foodCategory IS NULL OR r.restaurantInfo.foodCategory = :foodCategory)
             """)
-    List<Restaurant> findByPickeatIdAndIsExcludedIfProvided(@Param("pickeatId") Long pickeatId,
-                                                            @Param("isExcluded") Boolean isExcluded);
+    List<Restaurant> findByPickeatIdAndIsExcludedAndFoodCategoryIfProvided(
+            @Param("pickeatId") Long pickeatId,
+            @Param("isExcluded") Boolean isExcluded,
+            @Param("foodCategory") FoodCategory foodCategory);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "UPDATE restaurant SET deleted = true WHERE pickeat_id IN (:pickeatIds)", nativeQuery = true)

--- a/backend/src/main/java/com/pickeat/backend/restaurant/ui/RestaurantController.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/ui/RestaurantController.java
@@ -9,6 +9,7 @@ import com.pickeat.backend.restaurant.application.dto.request.RestaurantExcludeR
 import com.pickeat.backend.restaurant.application.dto.request.TemplateRestaurantRequest;
 import com.pickeat.backend.restaurant.application.dto.request.WishRestaurantRequest;
 import com.pickeat.backend.restaurant.application.dto.response.RestaurantResponse;
+import com.pickeat.backend.restaurant.domain.FoodCategory;
 import com.pickeat.backend.restaurant.ui.api.RestaurantApiSpec;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -98,9 +99,13 @@ public class RestaurantController implements RestaurantApiSpec {
     public ResponseEntity<List<RestaurantResponse>> getPickeatRestaurants(
             @PathVariable("pickeatCode") String pickeatCode,
             @RequestParam(required = false) Boolean isExcluded,
+            @RequestParam(required = false) FoodCategory foodCategory,
             @ParticipantInPickeat ParticipantPrincipal participantPrincipal
     ) {
-        List<RestaurantResponse> response = restaurantService.getPickeatRestaurants(pickeatCode, isExcluded,
+        List<RestaurantResponse> response = restaurantService.getPickeatRestaurants(
+                pickeatCode,
+                isExcluded,
+                foodCategory,
                 participantPrincipal.id());
         return ResponseEntity.ok().body(response);
     }

--- a/backend/src/main/java/com/pickeat/backend/restaurant/ui/api/RestaurantApiSpec.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/ui/api/RestaurantApiSpec.java
@@ -6,6 +6,7 @@ import com.pickeat.backend.restaurant.application.dto.request.RestaurantExcludeR
 import com.pickeat.backend.restaurant.application.dto.request.TemplateRestaurantRequest;
 import com.pickeat.backend.restaurant.application.dto.request.WishRestaurantRequest;
 import com.pickeat.backend.restaurant.application.dto.response.RestaurantResponse;
+import com.pickeat.backend.restaurant.domain.FoodCategory;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -433,6 +434,10 @@ public interface RestaurantApiSpec {
 
             @Parameter(description = "소거 여부 필터 ( --: 전체 식당 조회, true: 소거된 식당만, false: 소거되지 않은 식당만)")
             @RequestParam(required = false) Boolean isExcluded,
+
+            @Parameter(description = "음식 카테고리 필터 (지정하지 않으면 전체 카테고리 조회)")
+            @RequestParam(required = false) FoodCategory foodCategory,
+
             @Parameter(hidden = true) ParticipantPrincipal participantPrincipal
     );
 }

--- a/backend/src/test/java/com/pickeat/backend/fixture/RestaurantFixture.java
+++ b/backend/src/test/java/com/pickeat/backend/fixture/RestaurantFixture.java
@@ -32,4 +32,18 @@ public class RestaurantFixture {
                 pickeatId
         );
     }
+
+    public static Restaurant create(Long pickeatId, FoodCategory foodCategory) {
+        return new Restaurant(
+                "식당",
+                foodCategory,
+                10,
+                "도로명 주소",
+                "URL",
+                "태그1,태그2",
+                null,
+                null,
+                pickeatId
+        );
+    }
 }

--- a/backend/src/test/java/com/pickeat/backend/restaurant/application/RestaurantServiceTest.java
+++ b/backend/src/test/java/com/pickeat/backend/restaurant/application/RestaurantServiceTest.java
@@ -190,7 +190,7 @@ class RestaurantServiceTest {
 
             // when
             List<RestaurantResponse> restaurants = restaurantService.getPickeatRestaurants(
-                    pickeat.getCode().toString(), false, participant.getId());
+                    pickeat.getCode().toString(), false, null, participant.getId());
 
             // then
             assertThat(restaurants).hasSize(2);
@@ -210,7 +210,7 @@ class RestaurantServiceTest {
             // when
             restaurantService.like(restaurant1.getId(), participant.getId());
             List<RestaurantResponse> restaurants = restaurantService.getPickeatRestaurants(
-                    pickeat.getCode().toString(), false, participant.getId());
+                    pickeat.getCode().toString(), false, null, participant.getId());
 
             // then
             assertThat(restaurants.getFirst().isLiked()).isTrue();

--- a/backend/src/test/java/com/pickeat/backend/restaurant/domain/repository/RestaurantRepositoryTest.java
+++ b/backend/src/test/java/com/pickeat/backend/restaurant/domain/repository/RestaurantRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.pickeat.backend.fixture.PickeatFixture;
 import com.pickeat.backend.fixture.RestaurantFixture;
 import com.pickeat.backend.pickeat.domain.Pickeat;
+import com.pickeat.backend.restaurant.domain.FoodCategory;
 import com.pickeat.backend.restaurant.domain.Restaurant;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
@@ -27,19 +28,32 @@ class RestaurantRepositoryTest {
     void 식당_조회() {
         // given
         Pickeat pickeat = testEntityManager.persist(PickeatFixture.createWithoutRoom());
-        Restaurant restaurant1 = testEntityManager.persist(RestaurantFixture.create(pickeat.getId()));
-        Restaurant restaurant2 = testEntityManager.persist(RestaurantFixture.create(pickeat.getId()));
-        Restaurant restaurant3 = testEntityManager.persist(RestaurantFixture.create(pickeat.getId()));
+        Restaurant restaurant1 = testEntityManager.persist(
+                RestaurantFixture.create(pickeat.getId(), FoodCategory.KOREAN));
+        Restaurant restaurant2 = testEntityManager.persist(
+                RestaurantFixture.create(pickeat.getId(), FoodCategory.KOREAN));
+        Restaurant restaurant3 = testEntityManager.persist(
+                RestaurantFixture.create(pickeat.getId(), FoodCategory.OTHERS));
 
         restaurant2.exclude();
 
         // when & then
         assertAll(
-                () -> assertThat(restaurantRepository.findByPickeatIdAndIsExcludedIfProvided(pickeat.getId(), true))
+                () -> assertThat(
+                        restaurantRepository.findByPickeatIdAndIsExcludedAndFoodCategoryIfProvided(pickeat.getId(),
+                                true, null))
                         .hasSize(1),
-                () -> assertThat(restaurantRepository.findByPickeatIdAndIsExcludedIfProvided(pickeat.getId(), false))
+                () -> assertThat(
+                        restaurantRepository.findByPickeatIdAndIsExcludedAndFoodCategoryIfProvided(pickeat.getId(),
+                                false, null))
                         .hasSize(2),
-                () -> assertThat(restaurantRepository.findByPickeatIdAndIsExcludedIfProvided(pickeat.getId(), null))
+                () -> assertThat(
+                        restaurantRepository.findByPickeatIdAndIsExcludedAndFoodCategoryIfProvided(pickeat.getId(),
+                                null, FoodCategory.KOREAN))
+                        .hasSize(2),
+                () -> assertThat(
+                        restaurantRepository.findByPickeatIdAndIsExcludedAndFoodCategoryIfProvided(pickeat.getId(),
+                                null, null))
                         .hasSize(3)
         );
     }


### PR DESCRIPTION
## Issue Number
#460 

## As-Is
1. 카테고리 별 식당 조회 추가


## To-Be
카테고리 별 식당 조회 추가를 위해 식당 조회 API 에 RequestParam 추가 및 JPQL 상 조건 추가했습니다.
추가로, 메인 브랜치에서 Hotfix 과정에서 누락된 CICD 경로 조건을 함께 포함합니다.
별도의 작업으로 나눌 수 있으나, 변경점이 작고 현 운영 서버에 영향을 주는 작업이 아니라 포함하였습니다.



## Check List
- [x] 빌드, 테스트가 전부 통과되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?


## (Optional) Additional Description

Close #460
