### PR TITLE
[Feat] 불필요한 polling 제거를 위한 sse 도입

### DIFF
--- a/backend/src/main/java/com/pickeat/backend/pickeat/domain/repository/PickeatRepository.java
+++ b/backend/src/main/java/com/pickeat/backend/pickeat/domain/repository/PickeatRepository.java
@@ -18,6 +18,4 @@ public interface PickeatRepository extends JpaRepository<Pickeat, Long> {
     List<Pickeat> findByRoomIdIn(List<Long> roodIds);
 
     List<Pickeat> findByUpdatedAtBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
-
-    String findCodeById(Long id);
 }

--- a/backend/src/main/java/com/pickeat/backend/pickeat/domain/repository/PickeatRepository.java
+++ b/backend/src/main/java/com/pickeat/backend/pickeat/domain/repository/PickeatRepository.java
@@ -18,4 +18,6 @@ public interface PickeatRepository extends JpaRepository<Pickeat, Long> {
     List<Pickeat> findByRoomIdIn(List<Long> roodIds);
 
     List<Pickeat> findByUpdatedAtBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+    String findCodeById(Long id);
 }

--- a/backend/src/main/java/com/pickeat/backend/restaurant/application/RestaurantService.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/application/RestaurantService.java
@@ -19,6 +19,7 @@ import com.pickeat.backend.restaurant.domain.repository.RestaurantRepository;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +33,7 @@ public class RestaurantService {
     private final PickeatRepository pickeatRepository;
     private final ParticipantRepository participantRepository;
     private final RestaurantLikeRepository restaurantLikeRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
     public void create(List<RestaurantRequest> restaurantRequests, String pickeatCode) {
@@ -79,6 +81,8 @@ public class RestaurantService {
         List<Restaurant> restaurants = restaurantRepository.findAllById(request.restaurantIds());
         validateParticipantAccessToRestaurants(restaurants, participant);
         restaurants.forEach(Restaurant::exclude);
+
+        applicationEventPublisher.publishEvent(new RestaurantUpdatedEvent(participant.getPickeatId()));
     }
 
     @Transactional
@@ -92,6 +96,8 @@ public class RestaurantService {
         validateParticipantAccessToRestaurants(List.of(restaurant), participant);
         restaurantLikeRepository.save(new RestaurantLike(participantId, restaurantId));
         restaurant.like();
+
+        applicationEventPublisher.publishEvent(new RestaurantUpdatedEvent(restaurant.getPickeatId()));
     }
 
     @Transactional
@@ -104,6 +110,8 @@ public class RestaurantService {
 
         Restaurant restaurant = getRestaurantById(restaurantId);
         restaurant.cancelLike();
+
+        applicationEventPublisher.publishEvent(new RestaurantUpdatedEvent(restaurant.getPickeatId()));
     }
 
     private Participant getParticipant(Long participantId) {

--- a/backend/src/main/java/com/pickeat/backend/restaurant/application/RestaurantUpdatedEvent.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/application/RestaurantUpdatedEvent.java
@@ -1,0 +1,5 @@
+package com.pickeat.backend.restaurant.application;
+
+public record RestaurantUpdatedEvent(Long pickeatId) {
+
+}

--- a/backend/src/main/java/com/pickeat/backend/restaurant/application/RestaurantUpdatedEventHandler.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/application/RestaurantUpdatedEventHandler.java
@@ -1,0 +1,20 @@
+package com.pickeat.backend.restaurant.application;
+
+import com.pickeat.backend.pickeat.domain.repository.PickeatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class RestaurantUpdatedEventHandler {
+
+    private final PickeatRepository pickeatRepository;
+    private final SseServerClient sseServerClient;
+
+    @TransactionalEventListener()
+    void on(RestaurantUpdatedEvent restaurantUpdatedEvent) {
+        String pickeatCode = pickeatRepository.findCodeById(restaurantUpdatedEvent.pickeatId());
+        sseServerClient.notifyRestaurantUpdated(pickeatCode);
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/restaurant/application/RestaurantUpdatedEventHandler.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/application/RestaurantUpdatedEventHandler.java
@@ -1,5 +1,8 @@
 package com.pickeat.backend.restaurant.application;
 
+import com.pickeat.backend.global.exception.BusinessException;
+import com.pickeat.backend.global.exception.ErrorCode;
+import com.pickeat.backend.pickeat.domain.Pickeat;
 import com.pickeat.backend.pickeat.domain.repository.PickeatRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,7 +17,9 @@ public class RestaurantUpdatedEventHandler {
 
     @TransactionalEventListener()
     void on(RestaurantUpdatedEvent restaurantUpdatedEvent) {
-        String pickeatCode = pickeatRepository.findCodeById(restaurantUpdatedEvent.pickeatId());
-        sseServerClient.notifyRestaurantUpdated(pickeatCode);
+        Pickeat pickeat = pickeatRepository.findById(restaurantUpdatedEvent.pickeatId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PICKEAT_NOT_FOUND));
+
+        sseServerClient.notifyRestaurantUpdated(pickeat.getCode().getValue().toString());
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/restaurant/application/SseServerClient.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/application/SseServerClient.java
@@ -1,0 +1,6 @@
+package com.pickeat.backend.restaurant.application;
+
+public interface SseServerClient {
+
+    void notifyRestaurantUpdated(String message);
+}

--- a/backend/src/main/java/com/pickeat/backend/restaurant/infrastructure/RestaurantSseServerClient.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/infrastructure/RestaurantSseServerClient.java
@@ -1,19 +1,37 @@
 package com.pickeat.backend.restaurant.infrastructure;
 
+import com.pickeat.backend.global.exception.BusinessException;
+import com.pickeat.backend.global.exception.ErrorCode;
+import com.pickeat.backend.global.exception.ExternalApiException;
 import com.pickeat.backend.restaurant.application.SseServerClient;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RestClient;
 
 @RequiredArgsConstructor
 public class RestaurantSseServerClient implements SseServerClient {
 
     private final RestClient restClient;
+    private static final String PLATFORM_NAME = "sse";
 
     @Override
     public void notifyRestaurantUpdated(String pickeatCode) {
         restClient.post()
                 .uri("/internal/sse/pickeat/{pickeatCode}", pickeatCode)
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, (request, response) -> handleError(response))
                 .toBodilessEntity();
+    }
+
+    private void handleError(ClientHttpResponse response) {
+        try {
+            HttpStatus status = HttpStatus.valueOf(response.getStatusCode().value());
+            throw new ExternalApiException("sse-server-error", PLATFORM_NAME, status);
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+        }
     }
 }

--- a/backend/src/main/java/com/pickeat/backend/restaurant/infrastructure/RestaurantSseServerClient.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/infrastructure/RestaurantSseServerClient.java
@@ -1,0 +1,19 @@
+package com.pickeat.backend.restaurant.infrastructure;
+
+import com.pickeat.backend.restaurant.application.SseServerClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.client.RestClient;
+
+@RequiredArgsConstructor
+public class RestaurantSseServerClient implements SseServerClient {
+
+    private final RestClient restClient;
+
+    @Override
+    public void notifyRestaurantUpdated(String pickeatCode) {
+        restClient.post()
+                .uri("/internal/sse/pickeat/{pickeatCode}", pickeatCode)
+                .retrieve()
+                .toBodilessEntity();
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/restaurant/infrastructure/RestaurantSseServerClientConfig.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/infrastructure/RestaurantSseServerClientConfig.java
@@ -1,0 +1,27 @@
+package com.pickeat.backend.restaurant.infrastructure;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestaurantSseServerClientConfig {
+
+    @Bean
+    public RestaurantSseServerClient restaurantSseServerClient(
+            RestaurantSseServerProperties properties) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.getConnectTimeout());
+        factory.setReadTimeout(properties.getReadTimeout());
+
+        RestClient restClient = RestClient.builder()
+                .requestFactory(factory)
+                .baseUrl(properties.getBaseUrl())
+                .defaultHeader("X-INTERNAL-API-KEY", properties.getRestApiKey())
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+
+        return new RestaurantSseServerClient(restClient);
+    }
+}

--- a/backend/src/main/java/com/pickeat/backend/restaurant/infrastructure/RestaurantSseServerProperties.java
+++ b/backend/src/main/java/com/pickeat/backend/restaurant/infrastructure/RestaurantSseServerProperties.java
@@ -1,0 +1,24 @@
+package com.pickeat.backend.restaurant.infrastructure;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Validated
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "sse.server")
+public class RestaurantSseServerProperties {
+
+    @NotBlank(message = "baseUrl이 누락되었습니다.")
+    private String baseUrl;
+    @NotBlank(message = "restApiKey가 누락되었습니다.")
+    private String restApiKey;
+    @NotNull(message = "readTimeOut이 누락되었습니다.")
+    private Integer readTimeout;
+    @NotNull(message = "connectTimeout이 누락되었습니다.")
+    private Integer connectTimeout;
+}


### PR DESCRIPTION
## Issue Number
#471 

## 기존 문제
기존에는 polling 방식을 사용하여 투표 과정의 상태 변화를 주기적으로 확인하고 있었습니다.
3초마다 식당 데이터를 새로 요청하는 방식은 서버와 클라이언트 양측 모두에 불필요한 부하를 발생시키는 구조였습니다.

* 3초마다 새로운 HTTP connection 생성 및 소멸이 반복됨
* 픽잇(투표) 1건당 평균 4명이 약 3분간 참여할 경우, 서버는 해당 픽잇에 대해 약 240회의 요청을 처리해야 함
* 실제로 투표 상태에 변화가 없는 경우에도 클라이언트는 동일한 식당 정보를 반복적으로 요청해야 함

이로 인해 네트워크 자원 낭비와 서버 부하 증가라는 문제가 지속적으로 발생하고 있었습니다.

따라서 이러한 문제를 해결하기 위해 polling 방식 대신 SSE(Server-Sent Events) 방식을 도입하였습니다.

## 적용
SSE를 도입하여 투표 상태가 실제로 변경되는 시점에만 클라이언트에 알림을 전달하는 구조로 개선하였습니다.

구체적으로는 다음과 같은 흐름을 사용합니다.
* 기존 서비스 로직의 마지막 단계에서 투표 상태 변경 시점에 도메인 이벤트를 발생시킴
* 이벤트 리스너가 해당 이벤트를 수신하여 SSE 서버로 POST 요청을 전송
* SSE 서버는 연결된 클라이언트에게 투표 상태가 변경되었음을 즉시 전달

<img width="1798" height="1062" alt="image" src="https://github.com/user-attachments/assets/9359b0c0-573b-4bcd-a92e-ce539ff78388" />

이를 통해 불필요한 주기적 요청을 제거하고, 상태 변경에 대해서만 효율적으로 클라이언트에 알림을 전달할 수 있도록 개선하였습니다.


## 추후 적용할 점
* 테스트 코드 추가
  